### PR TITLE
[codex] stabilize trust-critical quality paths

### DIFF
--- a/src/components/ApiKeysSettings.tsx
+++ b/src/components/ApiKeysSettings.tsx
@@ -32,6 +32,17 @@ interface ApiKeys {
   [key: string]: ApiKey;
 }
 
+const getCurrentLLMProviderLabel = (provider?: string) => {
+  const providerLabels: Record<string, string> = {
+    openai: 'OpenAI',
+    anthropic: 'Anthropic',
+    local: 'Local LLM',
+    custom: 'Custom API',
+  };
+
+  return providerLabels[provider || 'openai'] || 'LLM';
+};
+
 const ApiKeysSettings: React.FC = () => {
   const [apiKeys, setApiKeys] = useState<ApiKeys>({});
   const [showKeys, setShowKeys] = useState<Record<string, boolean>>({});
@@ -49,7 +60,12 @@ const ApiKeysSettings: React.FC = () => {
     
     // 既存のLLM APIキー
     if (settings.apiKey) {
-      keys['openai'] = { name: 'OpenAI API Key', key: settings.apiKey, provider: 'openai' };
+      const providerLabel = getCurrentLLMProviderLabel(settings.provider);
+      keys['llm-current'] = {
+        name: `${providerLabel} API Key`,
+        key: settings.apiKey,
+        provider: 'llm'
+      };
     }
     
     // Web検索APIキー
@@ -81,7 +97,7 @@ const ApiKeysSettings: React.FC = () => {
     
     // プロバイダー別に保存
     switch (keyData.provider) {
-      case 'openai':
+      case 'llm':
         settings.apiKey = keyData.key;
         break;
       case 'google':
@@ -119,7 +135,7 @@ const ApiKeysSettings: React.FC = () => {
     const keyData = apiKeys[id];
     
     switch (keyData.provider) {
-      case 'openai':
+      case 'llm':
         delete settings.apiKey;
         break;
       case 'google':
@@ -165,7 +181,7 @@ const ApiKeysSettings: React.FC = () => {
 
   const getProviderIcon = (provider: string) => {
     const icons: Record<string, JSX.Element> = {
-      openai: <Brain className="w-4 h-4" />,
+      llm: <Brain className="w-4 h-4" />,
       google: <Search className="w-4 h-4" />,
       brave: <Globe className="w-4 h-4" />,
       bing: <Search className="w-4 h-4" />,
@@ -176,7 +192,7 @@ const ApiKeysSettings: React.FC = () => {
 
   const getProviderColor = (provider: string) => {
     const colors: Record<string, string> = {
-      openai: 'bg-green-500',
+      llm: 'bg-green-500',
       google: 'bg-blue-500',
       brave: 'bg-orange-500',
       bing: 'bg-purple-500',
@@ -186,7 +202,7 @@ const ApiKeysSettings: React.FC = () => {
   };
 
   const predefinedKeys = [
-    { id: 'openai', name: 'OpenAI API Key', provider: 'openai', description: 'GPT-3.5/GPT-4 アクセス用' },
+    { id: 'llm-current', name: 'Current LLM API Key', provider: 'llm', description: '設定画面で選択中のLLMプロバイダー用' },
     { id: 'google', name: 'Google Search API Key', provider: 'google', description: 'Google Custom Search API用' },
     { id: 'google-cse', name: 'Google Search Engine ID', provider: 'google', description: 'カスタム検索エンジンID' },
     { id: 'brave', name: 'Brave Search API Key', provider: 'brave', description: 'Brave Search API用' },
@@ -347,7 +363,7 @@ const ApiKeysSettings: React.FC = () => {
                   >
                     <option value="">プロバイダーを選択</option>
                     <option value="custom">カスタム</option>
-                    <option value="openai">OpenAI</option>
+                    <option value="llm">Current LLM</option>
                     <option value="google">Google</option>
                     <option value="brave">Brave</option>
                     <option value="bing">Bing</option>
@@ -364,7 +380,7 @@ const ApiKeysSettings: React.FC = () => {
         <Alert variant={"default" as const} className="">
           <Shield className="h-4 w-4" />
           <AlertDescription className="">
-            APIキーは暗号化されてローカルに保存されます。外部サーバーには送信されません。
+            APIキーはこのブラウザのローカルストレージに保存されます。外部サーバーへ自動送信はされませんが、共有端末では取り扱いに注意してください。
           </AlertDescription>
         </Alert>
       </CardContent>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -19,13 +19,24 @@ interface ChatHistoryItem {
   isError?: boolean;
 }
 
+const createTimestamp = () => new Date().toISOString()
+
+const formatTimestamp = (timestamp: string) => {
+  const parsed = new Date(timestamp)
+  if (Number.isNaN(parsed.getTime())) {
+    return timestamp
+  }
+
+  return parsed.toLocaleString('ja-JP')
+}
+
 const ChatView: React.FC = () => {
   const [messages, setMessages] = useState<ChatHistoryItem[]>([
     {
       id: '1',
       role: 'assistant',
       message: 'Hello! Welcome to 🌊 flomoji. How can I help you today?',
-      timestamp: new Date().toLocaleTimeString()
+      timestamp: createTimestamp()
     }
   ])
   const [inputValue, setInputValue] = useState('')
@@ -48,7 +59,7 @@ const ChatView: React.FC = () => {
       id: Date.now().toString(),
       role: 'user',
       message: inputValue,
-      timestamp: new Date().toLocaleTimeString()
+      timestamp: createTimestamp()
     }
 
     setMessages(prev => [...prev, userMessage])
@@ -63,7 +74,7 @@ const ChatView: React.FC = () => {
         id: (Date.now() + 1).toString(),
         role: 'assistant',
         message: response,
-        timestamp: new Date().toLocaleTimeString()
+        timestamp: createTimestamp()
       }
       
       setMessages(prev => [...prev, botMessage])
@@ -81,7 +92,7 @@ const ChatView: React.FC = () => {
         id: (Date.now() + 1).toString(),
         role: 'assistant',
         message: `An error occurred: ${error.message}`,
-        timestamp: new Date().toLocaleTimeString(),
+        timestamp: createTimestamp(),
         isError: true
       }
       
@@ -105,7 +116,7 @@ const ChatView: React.FC = () => {
           id: '1',
           role: 'assistant',
           message: 'Chat history cleared. Let\'s start a new conversation!',
-          timestamp: new Date().toLocaleTimeString()
+          timestamp: createTimestamp()
         }
       ])
       StorageService.remove(StorageService.KEYS.CHAT_HISTORY)
@@ -170,7 +181,7 @@ const ChatView: React.FC = () => {
                           ? 'text-red-400' 
                           : 'text-gray-400'
                     }`}>
-                      {message.timestamp}
+                      {formatTimestamp(message.timestamp)}
                     </p>
                   </div>
                 </div>

--- a/src/components/DataView.tsx
+++ b/src/components/DataView.tsx
@@ -11,7 +11,7 @@ import StorageService from '../services/storageService'
 import { Workflow as WorkflowType, ChatHistoryItem, Session, ParsedWorkflowRun, ParsedNodeLog } from '../types'
 
 const DataView = () => {
-  const [_chatHistory, setChatHistory] = useState<Session[]>([])
+  const [chatSessions, setChatSessions] = useState<Session[]>([])
   const [workflowData, setWorkflowData] = useState<WorkflowType[]>([])
   const [sortBy, setSortBy] = useState('timestamp') // 'timestamp' or 'name'
   const [sortOrder, setSortOrder] = useState('desc') // 'asc' or 'desc'
@@ -25,7 +25,7 @@ const DataView = () => {
     try {
       const history = StorageService.getChatHistory([])
       const sessions = groupChatMessages(history)
-      setChatHistory(sessions)
+      setChatSessions(sessions)
     } catch (error) {
       errorService.logError(error as Error, {
         context: 'load_chat_history'
@@ -33,7 +33,7 @@ const DataView = () => {
         category: 'system',
         userMessage: 'チャット履歴の読み込みに失敗しました'
       })
-      setChatHistory([])
+      setChatSessions([])
     }
 
     // ワークフローデータを読み込み
@@ -359,10 +359,62 @@ const DataView = () => {
         </TabsList>
 
         <TabsContent value="chat" className="space-y-4 mt-6">
-          <Card className="p-6">
-            <CardContent className="text-center text-gray-500">
-              <MessageSquare className="h-12 w-12 mx-auto mb-4 text-gray-400" />
-              <p>Chat history feature coming soon</p>
+          <div className="flex justify-between items-center">
+            <div className="flex items-center space-x-4">
+              <h3 className="text-lg font-semibold">Chat Sessions ({chatSessions.length} items)</h3>
+            </div>
+            <Button variant="outline" onClick={() => handleExportData('chat')} disabled={chatSessions.length === 0}>
+              <Download className="h-4 w-4 mr-2" />Export Chat History
+            </Button>
+          </div>
+          <Card className="overflow-hidden">
+            <CardContent className="p-0">
+              {chatSessions.length === 0 ? (
+                <div className="text-center py-12">
+                  <MessageSquare className="h-12 w-12 mx-auto mb-4 text-gray-400" />
+                  <p className="text-gray-500">No chat history available</p>
+                  <p className="text-sm text-gray-400 mt-1">Start a chat to see saved conversations here</p>
+                </div>
+              ) : (
+                <div className="divide-y divide-gray-200">
+                  {chatSessions.map((session) => (
+                    <div key={session.id} className="p-5 space-y-4">
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <p className="font-medium text-gray-900">{session.title}</p>
+                          <div className="flex flex-wrap items-center gap-3 text-sm text-gray-500 mt-1">
+                            <span>{session.messageCount} messages</span>
+                            <span>Created: {formatDate(session.createdAt)}</span>
+                            <span>Last activity: {formatDate(session.lastActivity)}</span>
+                          </div>
+                        </div>
+                        <Badge variant="secondary">{session.messages.length} entries</Badge>
+                      </div>
+
+                      <div className="space-y-2">
+                        {session.messages.map((message) => (
+                          <div
+                            key={message.id}
+                            className={`rounded-lg border p-3 ${
+                              message.role === 'user'
+                                ? 'bg-blue-50 border-blue-100'
+                                : 'bg-gray-50 border-gray-200'
+                            }`}
+                          >
+                            <div className="flex items-center justify-between gap-3 mb-1">
+                              <Badge variant={message.role === 'user' ? 'default' : 'outline'}>
+                                {message.role}
+                              </Badge>
+                              <span className="text-xs text-gray-500">{formatDate(message.timestamp)}</span>
+                            </div>
+                            <p className="text-sm whitespace-pre-wrap text-gray-800">{message.message}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>

--- a/src/components/ReactFlowEditor/nodes/LLMNodeComponent.tsx
+++ b/src/components/ReactFlowEditor/nodes/LLMNodeComponent.tsx
@@ -37,7 +37,7 @@ const LLMNodeComponent = ({ id, data }: any) => {
           />
         </div>
         <div className="text-xs text-gray-400">
-          Model: {data.model || 'gpt-3.5-turbo'}
+          Model: {data.model || 'gpt-5-nano'}
         </div>
       </div>
     </CustomNode>

--- a/src/components/nodes/HTTPRequestNode.test.ts
+++ b/src/components/nodes/HTTPRequestNode.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { executeHTTPRequestNode } from './HTTPRequestNode';
+import StorageService from '../../services/storageService';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value.toString();
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+  };
+})();
+
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+  writable: true
+});
+
+describe('HTTPRequestNode templates', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    localStorageMock.clear();
+  });
+
+  it('should inject the current LLM API key into the OpenAI template and use POST', async () => {
+    StorageService.setSettings({
+      apiKey: 'sk-test-key'
+    });
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        entries: () => [['content-type', 'application/json']],
+        get: () => 'application/json'
+      },
+      json: async () => ({ ok: true }),
+      text: async () => ''
+    });
+
+    const result = await executeHTTPRequestNode(
+      {
+        id: 'http-1',
+        type: 'http_request',
+        position: { x: 0, y: 0 },
+        data: {
+          useTemplate: true,
+          template: 'openai-completion'
+        }
+      },
+      {
+        query: 'hello world'
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sk-test-key',
+          'Content-Type': 'application/json'
+        }),
+        body: expect.stringContaining('"model":"gpt-5-nano"')
+      })
+    );
+    expect(result.error).toBeNull();
+    expect(result.response).toEqual({ ok: true });
+  });
+
+  it('should fail fast when required Google template settings are missing', async () => {
+    await expect(
+      executeHTTPRequestNode(
+        {
+          id: 'http-1',
+          type: 'http_request',
+          position: { x: 0, y: 0 },
+          data: {
+            useTemplate: true,
+            template: 'google-search'
+          }
+        },
+        {
+          query: 'flomoji'
+        }
+      )
+    ).rejects.toThrow('Google Search API Key が設定されていません');
+  });
+});

--- a/src/components/nodes/HTTPRequestNode.ts
+++ b/src/components/nodes/HTTPRequestNode.ts
@@ -1,3 +1,4 @@
+import StorageService from '../../services/storageService';
 import { createNodeDefinition } from './types';
 import type { WorkflowNode, NodeInputs, INodeExecutionContext, NodeOutput } from '../../types';
 import type { HTTPRequestNodeData } from '../../types/nodeData';
@@ -8,12 +9,14 @@ export async function executeHTTPRequestNode(node: WorkflowNode, inputs: NodeInp
   const { method = 'GET', url, headers = {}, timeout = 30000, useTemplate, template } = data;
   
   // テンプレート使用時の処理
+  let finalMethod = method;
   let finalUrl = url;
   let finalHeaders = headers;
   let body = inputs.body || data.body;
   
   if (useTemplate && template) {
     const templateConfig = getTemplateConfig(template || '', (inputs.query as string) || '');
+    finalMethod = templateConfig.method || finalMethod;
     finalUrl = templateConfig.url;
     finalHeaders = { ...templateConfig.headers, ...(typeof headers === 'object' && headers !== null ? headers : {}) };
     body = templateConfig.body || body;
@@ -44,12 +47,12 @@ export async function executeHTTPRequestNode(node: WorkflowNode, inputs: NodeInp
   
   // リクエストオプション
   const requestOptions: any = {
-    method,
+    method: finalMethod,
     headers: processedHeaders,
   };
   
   // ボディの処理（GET以外）
-  if (method !== 'GET' && body) {
+  if (finalMethod !== 'GET' && body) {
     if (typeof body === 'object') {
       requestOptions.body = JSON.stringify(body);
       const headers = processedHeaders as Record<string, string>;
@@ -116,66 +119,110 @@ export async function executeHTTPRequestNode(node: WorkflowNode, inputs: NodeInp
 }
 
 // テンプレート設定を取得
-function getTemplateConfig(templateName: string, query: string): any {
-  const templates = {
-    'google-search': {
-      url: `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(query)}&key=YOUR_API_KEY&cx=YOUR_SEARCH_ENGINE_ID`,
-      headers: {
-        'Accept': 'application/json'
-      },
-      description: 'Google Custom Search API'
-    },
-    'brave-search': {
-      url: `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=10`,
-      headers: {
-        'Accept': 'application/json',
-        'X-Subscription-Token': 'YOUR_API_KEY'
-      },
-      description: 'Brave Search API'
-    },
-    'bing-search': {
-      url: `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(query)}&count=10`,
-      headers: {
-        'Ocp-Apim-Subscription-Key': 'YOUR_API_KEY',
-        'Accept': 'application/json'
-      },
-      description: 'Bing Search API'
-    },
-    'openai-completion': {
-      url: 'https://api.openai.com/v1/chat/completions',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer YOUR_API_KEY'
-      },
-      body: {
-        model: 'gpt-3.5-turbo',
-        messages: [{ role: 'user', content: query }],
-        temperature: 0.7
-      },
-      description: 'OpenAI Chat Completion'
-    },
-    'anthropic-completion': {
-      url: 'https://api.anthropic.com/v1/messages',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': 'YOUR_API_KEY',
-        'anthropic-version': '2023-06-01'
-      },
-      body: {
-        model: 'claude-3-sonnet-20240229',
-        max_tokens: 1024,
-        messages: [{ role: 'user', content: query }]
-      },
-      description: 'Anthropic Claude API'
-    }
-  };
-  
-  const template = templates[templateName as keyof typeof templates];
-  if (!template) {
-    throw new Error(`未知のテンプレート: ${templateName}`);
+type HTTPTemplateConfig = {
+  method?: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: any;
+  description: string;
+};
+
+function requireSetting(value: string | undefined, label: string): string {
+  if (!value || !value.trim()) {
+    throw new Error(`${label} が設定されていません。設定画面で値を保存してください。`);
   }
-  
-  return template;
+
+  return value;
+}
+
+function getTemplateConfig(templateName: string, query: string): HTTPTemplateConfig {
+  const settings = StorageService.getSettings({});
+
+  switch (templateName) {
+    case 'google-search': {
+      const apiKey = requireSetting(settings.googleApiKey, 'Google Search API Key');
+      const searchEngineId = requireSetting(settings.googleSearchEngineId, 'Google Search Engine ID');
+
+      return {
+        method: 'GET',
+        url: `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(query)}&key=${encodeURIComponent(apiKey)}&cx=${encodeURIComponent(searchEngineId)}`,
+        headers: {
+          'Accept': 'application/json'
+        },
+        description: 'Google Custom Search API'
+      };
+    }
+
+    case 'brave-search': {
+      const apiKey = requireSetting(settings.braveApiKey, 'Brave Search API Key');
+
+      return {
+        method: 'GET',
+        url: `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=10`,
+        headers: {
+          'Accept': 'application/json',
+          'X-Subscription-Token': apiKey
+        },
+        description: 'Brave Search API'
+      };
+    }
+
+    case 'bing-search': {
+      const apiKey = requireSetting(settings.bingApiKey, 'Bing Search API Key');
+
+      return {
+        method: 'GET',
+        url: `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(query)}&count=10`,
+        headers: {
+          'Ocp-Apim-Subscription-Key': apiKey,
+          'Accept': 'application/json'
+        },
+        description: 'Bing Search API'
+      };
+    }
+
+    case 'openai-completion': {
+      const apiKey = requireSetting(settings.apiKey, 'Current LLM API Key');
+
+      return {
+        method: 'POST',
+        url: 'https://api.openai.com/v1/chat/completions',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`
+        },
+        body: {
+          model: 'gpt-5-nano',
+          messages: [{ role: 'user', content: query }],
+          temperature: 0.7
+        },
+        description: 'OpenAI Chat Completion'
+      };
+    }
+
+    case 'anthropic-completion': {
+      const apiKey = requireSetting(settings.apiKey, 'Current LLM API Key');
+
+      return {
+        method: 'POST',
+        url: 'https://api.anthropic.com/v1/messages',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01'
+        },
+        body: {
+          model: 'claude-3-5-sonnet-20241022',
+          max_tokens: 1024,
+          messages: [{ role: 'user', content: query }]
+        },
+        description: 'Anthropic Claude API'
+      };
+    }
+
+    default:
+      throw new Error(`未知のテンプレート: ${templateName}`);
+  }
 }
 
 // ノード定義

--- a/src/constants/apiTemplates.ts
+++ b/src/constants/apiTemplates.ts
@@ -48,7 +48,7 @@ export const API_TEMPLATES: Record<string, (query: string, apiKey?: string) => A
       'Authorization': `Bearer ${apiKey || '{API_KEY}'}`
     },
     body: {
-      model: 'gpt-3.5-turbo',
+      model: 'gpt-5-nano',
       messages: [{ role: 'user', content: query }],
       temperature: 0.7
     },

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -63,7 +63,7 @@ class LLMService {
       provider: 'openai',
       apiKey: '',
       baseUrl: '',
-      model: 'gpt-3.5-turbo',
+      model: 'gpt-5-nano',
       temperature: 0.7,
       maxTokens: 2048
     }) as ExtendedLLMSettings;
@@ -73,7 +73,7 @@ class LLMService {
         provider: 'openai',
         apiKey: '',
         baseUrl: '',
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-5-nano',
         temperature: 0.7,
         maxTokens: 2048
       };

--- a/src/services/nodeExecutionService.test.ts
+++ b/src/services/nodeExecutionService.test.ts
@@ -3,7 +3,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import * as llmService from './llmService';
+import logService from './logService';
 import nodeExecutionService from './nodeExecutionService';
+import StorageService from './storageService';
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -188,6 +190,23 @@ describe('nodeExecutionService', () => {
       
       // Clean up
       nodeExecutionService.stopExecution();
+    });
+
+    it('should use the persisted current workflow ID for execution logs', async () => {
+      const createRunSpy = vi.spyOn(logService, 'createRun').mockResolvedValue('run-1');
+      StorageService.setCurrentWorkflowId('workflow-123');
+
+      const nodes: any[] = [
+        {
+          id: 'input-1',
+          type: 'input',
+          data: { value: 'test' }
+        }
+      ];
+
+      await nodeExecutionService.startExecution(nodes, [], {});
+
+      expect(createRunSpy).toHaveBeenCalledWith('workflow-123', {});
     });
 
     it('should handle circular dependencies', async () => {

--- a/src/services/nodeExecutionService.ts
+++ b/src/services/nodeExecutionService.ts
@@ -111,7 +111,7 @@ export class NodeExecutionService {
     }
 
     // Initialize execution context
-    const workflowId = StorageService.get<string>('currentWorkflowId') || 'default';
+    const workflowId = StorageService.getCurrentWorkflowId() || 'default';
     this.context = new ExecutionContext({
       debugMode: false,
       workflowId,


### PR DESCRIPTION
## What changed
- fixed workflow execution logging to use the persisted current workflow id
- made HTTP request templates use saved credentials and correct HTTP methods instead of placeholder values
- aligned default LLM model labels and service fallbacks to `gpt-5-nano`
- replaced the unfinished chat history placeholder with a real saved-session view
- corrected API key copy so storage behavior matches the implementation

## Why
These were trust-eroding issues in the current app surface: settings and labels did not always match runtime behavior, some templates were not runnable as configured, and Data Management exposed unfinished UI.

## Impact
- execution logs now attach to the active workflow consistently
- built-in API templates are usable once credentials are saved in settings
- chat history is inspectable/exportable from the app
- users see more accurate model and credential messaging

## Root cause
Several runtime paths had drifted from the current storage model and UI defaults. Placeholder template values and outdated fallback models remained in the code, and the data management screen still exposed a placeholder state.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`
