### PR TITLE
[codex] improve output node downloads

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,6 +24,7 @@ interface NodeData {
   variable?: string;
   operator?: string;
   format?: string;
+  title?: string;
   result?: string;
   variableName?: string;
   useInput?: boolean;
@@ -186,7 +187,51 @@ const NodePropertiesPanel = ({ editingNode, onEditingNodeChange }: NodePropertie
             )}
             </div></>) : (<><div><label className="block text-xs font-medium mb-1 text-gray-600">Variable Name</label><input type="text" value={editingNode.data.variable || ''} onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleDataChange({ variable: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="Variable name to compare" /></div><div><label className="block text-xs font-medium mb-1 text-gray-600">Operator</label><select value={editingNode.data.operator || '=='} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleDataChange({ operator: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="==">== (Equal)</option><option value="!=">!= (Not Equal)</option><option value="<">&lt; (Less Than)</option><option value="<=">&lt;= (Less Than or Equal)</option><option value=">">&gt; (Greater Than)</option><option value=">=">&gt;= (Greater Than or Equal)</option></select></div><div><label className="block text-xs font-medium mb-1 text-gray-600">Comparison Value</label><input type="text" value={editingNode.data.value || ''} onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleDataChange({ value: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="Value to compare" /></div></>)}</> )}
         {editingNode.type === 'while' && ( <><div><label className="block text-xs font-medium mb-1 text-gray-600">Condition Type</label><select value={editingNode.data.conditionType || 'variable'} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleDataChange({ conditionType: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="variable">Variable Comparison</option><option value="llm">LLM Judgment</option></select></div>{editingNode.data.conditionType === 'variable' ? (<><div><label className="block text-xs font-medium mb-1 text-gray-600">Variable Name</label><input type="text" value={editingNode.data.variable || ''} onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleDataChange({ variable: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="Variable name to compare" /></div><div><label className="block text-xs font-medium mb-1 text-gray-600">Operator</label><select value={editingNode.data.operator || '<'} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleDataChange({ operator: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="==">== (Equal)</option><option value="!=">!= (Not Equal)</option><option value="<">&lt; (Less Than)</option><option value="<=">&lt;= (Less Than or Equal)</option><option value=">">&gt; (Greater Than)</option><option value=">=">&gt;= (Greater Than or Equal)</option></select></div><div><label className="block text-xs font-medium mb-1 text-gray-600">Comparison Value</label><input type="text" value={editingNode.data.value || ''} onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleDataChange({ value: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="Value to compare" /></div></>) : (<div><label className="block text-xs font-medium mb-1 text-gray-600">Continue Condition</label><textarea value={editingNode.data.condition || ''} onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleDataChange({ condition: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" rows={3} placeholder="Enter condition to continue iteration" /></div>)}<div><label className="block text-xs font-medium mb-1 text-gray-600">Max Iterations</label><input type="number" value={editingNode.data.maxIterations || 100} onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleDataChange({ maxIterations: parseInt(e.target.value) })} className="w-full px-2 py-1.5 text-sm border rounded-md" min="1" max="1000" /></div></> )}
-        {editingNode.type === 'output' && ( <><div><label className="block text-xs font-medium mb-1 text-gray-600">Output Format</label><select value={editingNode.data.format || 'text'} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleDataChange({ format: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="text">Text</option><option value="json">JSON</option><option value="markdown">Markdown</option></select></div><div><label className="block text-xs font-medium mb-1 text-gray-600">Execution Result</label><textarea value={String(editingNode.data.result || '')} readOnly className="w-full px-3 py-2 border rounded-md bg-gray-100 resize-none" style={{ height: `${calculateTextAreaHeight(5)}px` }} /></div></> )}
+        {editingNode.type === 'output' && (
+          <>
+            <div>
+              <label className="block text-xs font-medium mb-1 text-gray-600">Output Title</label>
+              <input
+                type="text"
+                value={editingNode.data.title || ''}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleDataChange({ title: e.target.value })}
+                className="w-full px-2 py-1.5 text-sm border rounded-md"
+                placeholder="Result"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium mb-1 text-gray-600">Download File Name</label>
+              <input
+                type="text"
+                value={editingNode.data.fileName || ''}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleDataChange({ fileName: e.target.value })}
+                className="w-full px-2 py-1.5 text-sm border rounded-md"
+                placeholder="workflow-output"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium mb-1 text-gray-600">Output Format</label>
+              <select
+                value={editingNode.data.format || 'text'}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleDataChange({ format: e.target.value })}
+                className="w-full px-2 py-1.5 text-sm border rounded-md"
+              >
+                <option value="text">Text</option>
+                <option value="json">JSON</option>
+                <option value="markdown">Markdown</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium mb-1 text-gray-600">Execution Result</label>
+              <textarea
+                value={String(editingNode.data.result || '')}
+                readOnly
+                className="w-full px-3 py-2 border rounded-md bg-gray-100 resize-none"
+                style={{ height: `${calculateTextAreaHeight(5)}px` }}
+              />
+            </div>
+          </>
+        )}
         {editingNode.type === 'variable_set' && (
           <>
             <div><label className="block text-xs font-medium mb-1 text-gray-600">Variable Name</label><input type="text" value={editingNode.data.variableName || ''} onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleDataChange({ variableName: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="Variable name to set" /></div>

--- a/src/components/ReactFlowEditor/nodes/OutputNodeComponent.tsx
+++ b/src/components/ReactFlowEditor/nodes/OutputNodeComponent.tsx
@@ -7,6 +7,19 @@ import { Textarea } from '@/components/ui/textarea';
 
 import CustomNode from './CustomNode';
 
+const DOWNLOAD_CONFIG = {
+  text: { extension: 'txt', mimeType: 'text/plain;charset=utf-8', label: 'Text' },
+  json: { extension: 'json', mimeType: 'application/json;charset=utf-8', label: 'JSON' },
+  markdown: { extension: 'md', mimeType: 'text/markdown;charset=utf-8', label: 'Markdown' }
+} as const;
+
+const sanitizeFileName = (value: string) =>
+  value
+    .trim()
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
 
 const OutputNodeComponent = ({ id, data }: any) => {
   
@@ -18,15 +31,18 @@ const OutputNodeComponent = ({ id, data }: any) => {
     if (!displayResult || displayResult === 'No result yet...') {
       return;
     }
-    
+
+    const format = data.format || 'text';
+    const config = DOWNLOAD_CONFIG[format as keyof typeof DOWNLOAD_CONFIG] || DOWNLOAD_CONFIG.text;
+
     // Blobを作成してダウンロード
-    const blob = new Blob([displayResult], { type: 'text/plain;charset=utf-8' });
+    const blob = new Blob([displayResult], { type: config.mimeType });
     const url = URL.createObjectURL(blob);
-    
-    // 現在の日時をファイル名に使用
+
     const now = new Date();
     const timestamp = now.toISOString().replace(/[:.]/g, '-').slice(0, -5);
-    const filename = `output_${timestamp}.txt`;
+    const preferredName = sanitizeFileName(data.fileName || data.title || data.label || 'output');
+    const filename = `${preferredName || 'output'}_${timestamp}.${config.extension}`;
     
     // ダウンロードリンクを作成
     const link = document.createElement('a');
@@ -67,7 +83,7 @@ const OutputNodeComponent = ({ id, data }: any) => {
           className="w-full"
         >
           <Download className="w-4 h-4" />
-          Download as Text
+          Download as {(DOWNLOAD_CONFIG[data.format as keyof typeof DOWNLOAD_CONFIG] || DOWNLOAD_CONFIG.text).label}
         </Button>
       </div>
     </CustomNode>

--- a/src/components/nodes/OutputNode.test.ts
+++ b/src/components/nodes/OutputNode.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { OutputNode } from './OutputNode';
+
+describe('OutputNode', () => {
+  it('should keep plain text output as-is', async () => {
+    const result = await OutputNode.execute(
+      {
+        id: 'output-1',
+        type: 'output',
+        position: { x: 0, y: 0 },
+        data: { format: 'text', name: 'summary' }
+      },
+      {
+        input: 'hello world'
+      }
+    );
+
+    expect(result).toBe('hello world');
+  });
+
+  it('should serialize object output as formatted JSON', async () => {
+    const variables: Record<string, unknown> = {};
+    const context = {
+      variables,
+      addLog: () => undefined,
+      setVariable(key: string, value: unknown) {
+        variables[key] = value;
+      },
+      getVariable(key: string) {
+        return variables[key];
+      }
+    };
+
+    const result = await OutputNode.execute(
+      {
+        id: 'output-1',
+        type: 'output',
+        position: { x: 0, y: 0 },
+        data: { format: 'json', name: 'payload' }
+      },
+      {
+        input: { name: 'flomoji', count: 2 }
+      },
+      context
+    );
+
+    expect(result).toBe('{\n  "name": "flomoji",\n  "count": 2\n}');
+    expect(variables.payload).toBe(result);
+  });
+
+  it('should render objects as markdown code blocks when markdown output is selected', async () => {
+    const result = await OutputNode.execute(
+      {
+        id: 'output-1',
+        type: 'output',
+        position: { x: 0, y: 0 },
+        data: { format: 'markdown', name: 'report' }
+      },
+      {
+        input: { status: 'ok' }
+      }
+    );
+
+    expect(result).toContain('```json');
+    expect(result).toContain('"status": "ok"');
+  });
+});

--- a/src/components/nodes/OutputNode.ts
+++ b/src/components/nodes/OutputNode.ts
@@ -1,6 +1,42 @@
 import { createNodeDefinitionNew } from './types';
 import type { WorkflowNode, NodeInputs, INodeExecutionContext, NodeOutput } from '../../types';
 
+function formatOutputValue(value: unknown, format: string, outputName: string): string {
+  switch (format) {
+    case 'json': {
+      if (typeof value === 'string') {
+        try {
+          return JSON.stringify(JSON.parse(value), null, 2);
+        } catch {
+          return JSON.stringify({ [outputName]: value }, null, 2);
+        }
+      }
+
+      return JSON.stringify(value ?? { [outputName]: null }, null, 2);
+    }
+
+    case 'markdown': {
+      if (typeof value === 'string') {
+        return value;
+      }
+
+      return `\`\`\`json\n${JSON.stringify(value ?? { [outputName]: null }, null, 2)}\n\`\`\``;
+    }
+
+    case 'text':
+    default:
+      if (typeof value === 'string') {
+        return value;
+      }
+
+      if (value === null || value === undefined) {
+        return '';
+      }
+
+      return typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);
+  }
+}
+
 /**
  * 出力ノードの実行処理
  * @param node - ノードオブジェクト
@@ -16,22 +52,14 @@ async function executeOutputNode(
   const format = node.data.format || 'text';
   const inputValue = Object.values(inputs)[0] || '';
   const outputName = node.data.name || 'output';
+  const formattedOutput = formatOutputValue(inputValue, format, outputName);
 
   // Set the output value as a variable in the execution context
   if (context) {
-    context.setVariable(outputName, inputValue);
+    context.setVariable(outputName, formattedOutput);
   }
-  
-  switch (format) {
-    case 'json':
-      try {
-        return JSON.stringify({ [outputName]: inputValue }, null, 2);
-      } catch {
-        return inputValue;
-      }
-    default:
-      return inputValue;
-  }
+
+  return formattedOutput;
 }
 
 /**
@@ -48,11 +76,12 @@ export const OutputNode = createNodeDefinitionNew(
   {
     format: 'text',
     title: 'Result',
+    fileName: '',
     result: ''
   },
   executeOutputNode,
   {
-    description: 'Display workflow results. Supports text or structured data output.',
+    description: 'Display workflow results. Supports text, JSON, and Markdown output with browser download.',
     category: 'input-output'
   }
 );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,8 +96,9 @@ export interface NodeData extends Record<string, any> {
   fileContent?: string;
   name?: string;
   // For OutputNode
-  format?: 'text' | 'json';
+  format?: 'text' | 'json' | 'markdown';
   title?: string;
+  fileName?: string;
   // For WorkflowNode
   workflowId?: string;
   workflowName?: string;

--- a/src/types/nodeData.ts
+++ b/src/types/nodeData.ts
@@ -83,8 +83,9 @@ export interface InputNodeData {
 
 // OutputNode用の型定義
 export interface OutputNodeData {
-  format?: 'text' | 'json';
+  format?: 'text' | 'json' | 'markdown';
   title?: string;
+  fileName?: string;
   result?: string;
 }
 


### PR DESCRIPTION
## What changed
- expanded the Output node to produce text, JSON, or Markdown consistently
- added configurable download file names in the node properties panel
- made the Output node download button choose the correct extension and MIME type
- added focused tests for formatted Output node behavior

## Why
The project already exposed output formatting and download affordances, but they were only partially implemented. This made the node feel more capable than it actually was.

## Impact
- output workflows can now produce files that match the selected format
- users can name downloaded files intentionally instead of getting generic text dumps
- Markdown output is now a real supported path instead of a dead option in the UI

## Root cause
The Output node execution path, editor properties, and download UI had drifted apart. The UI offered options that the runtime and downloader did not honor.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`
