### PR TITLE
[codex] add starter workflow onboarding

### DIFF
--- a/src/components/ReactFlowEditor/index.tsx
+++ b/src/components/ReactFlowEditor/index.tsx
@@ -14,7 +14,9 @@ import workflowManagerService from '../../services/workflowManagerService';
 import { useStore as useUIStore } from '../../store';
 import useExecutionStore, { ExecutionStore } from '../../store/executionStore';
 import useReactFlowStore from '../../store/reactFlowStore';
+import { starterWorkflowTemplates } from '../../data/starterWorkflowTemplates';
 import ExecutionOutputWindow from '../ExecutionOutputWindow';
+import StarterWorkflowPanel from '../StarterWorkflowPanel';
 import { nodeTypes as nodeDefinitions } from '../nodes';
 import WorkflowToolbar from '../WorkflowToolbar';
 
@@ -97,7 +99,7 @@ const edgeTypes = {
   custom: CustomEdge,
 };
 
-const ReactFlowEditor = ({ selectedNode, onSelectedNodeChange, onEditingNodeChange, onOpenCopilot }: any) => {
+const ReactFlowEditor = ({ selectedNode, editingNode, onSelectedNodeChange, onEditingNodeChange, onOpenCopilot }: any) => {
   // 個別のセレクターを使用してZustandストアから値を取得
   const rawNodes = useReactFlowStore(selectNodes);
   const rawEdges = useReactFlowStore(selectEdges);
@@ -150,6 +152,7 @@ const ReactFlowEditor = ({ selectedNode, onSelectedNodeChange, onEditingNodeChan
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [showHandleLabels, setShowHandleLabels] = useState(true);
+  const [starterPanelDismissed, setStarterPanelDismissed] = useState(false);
 
   // useRefで安定した参照を作成（Phase 3最適化）
   const nodesRef = useRef(nodes);
@@ -173,6 +176,10 @@ const ReactFlowEditor = ({ selectedNode, onSelectedNodeChange, onEditingNodeChan
   useEffect(() => {
     viewportRef.current = viewport;
   }, [viewport]);
+
+  useEffect(() => {
+    setStarterPanelDismissed(false);
+  }, [currentWorkflow?.id]);
 
   // Initial load effect
   useEffect(() => {
@@ -479,6 +486,38 @@ const ReactFlowEditor = ({ selectedNode, onSelectedNodeChange, onEditingNodeChan
     setWorkflows(Object.values(workflowsData));
   }, [currentWorkflow]);
 
+  const handleApplyStarterTemplate = useCallback((templateId: string) => {
+    const template = starterWorkflowTemplates.find(entry => entry.id === templateId);
+    if (!template) {
+      toast.error('スターターテンプレートが見つかりませんでした');
+      return;
+    }
+
+    if (!currentWorkflow) {
+      toast.error('現在のワークフローを読み込めませんでした');
+      return;
+    }
+
+    const appliedWorkflow = workflowManagerService.applyTemplateToWorkflow(
+      currentWorkflow.id,
+      template.workflow
+    );
+
+    if (!appliedWorkflow) {
+      toast.error('テンプレートの適用に失敗しました');
+      return;
+    }
+
+    loadWorkflow(appliedWorkflow.id);
+    setCurrentWorkflow(appliedWorkflow);
+    setHasUnsavedChanges(false);
+    setStarterPanelDismissed(false);
+
+    const workflowsData = workflowManagerService.getWorkflows();
+    setWorkflows(Object.values(workflowsData));
+    toast.success(`"${template.name}" を読み込みました`);
+  }, [currentWorkflow, loadWorkflow]);
+
   // プロパティ変更をReactFlowストアに反映する関数は不要になったため削除
 
   const { handleRunAll, handleStepForward, handleResetExecution }: any = useWorkflowExecution({
@@ -750,6 +789,15 @@ const ReactFlowEditor = ({ selectedNode, onSelectedNodeChange, onEditingNodeChan
   // }, [setViewport]);
 
   // デバッグログを削除（不要な出力を減らす）
+  const isCurrentWorkflowEmpty =
+    !!currentWorkflow &&
+    nodes.length === 0 &&
+    edges.length === 0;
+
+  const showStarterWorkflowPanel =
+    isCurrentWorkflowEmpty &&
+    !starterPanelDismissed &&
+    !editingNode;
   
   return (
     <div style={{ width: '100%', height: '100%' }}>
@@ -836,6 +884,13 @@ Show Handle Labels
         </div>
         </ReactFlow>
       </HandleLabelsProvider>
+      {showStarterWorkflowPanel && (
+        <StarterWorkflowPanel
+          templates={starterWorkflowTemplates}
+          onApplyTemplate={handleApplyStarterTemplate}
+          onDismiss={() => setStarterPanelDismissed(true)}
+        />
+      )}
       <ContextMenu />
       
       {/* 実行結果ウィンドウ */}

--- a/src/components/StarterWorkflowPanel.tsx
+++ b/src/components/StarterWorkflowPanel.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import { ArrowRight, Sparkles } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+import type { StarterWorkflowTemplate } from '../data/starterWorkflowTemplates';
+
+interface StarterWorkflowPanelProps {
+  templates: StarterWorkflowTemplate[];
+  onApplyTemplate: (templateId: string) => void;
+  onDismiss: () => void;
+}
+
+const StarterWorkflowPanel = ({
+  templates,
+  onApplyTemplate,
+  onDismiss,
+}: StarterWorkflowPanelProps) => {
+  return (
+    <div className="absolute inset-0 z-40 pointer-events-none px-6 pt-24 pb-8">
+      <div className="mx-auto max-w-6xl pointer-events-auto">
+        <Card className="border-slate-200 bg-white/95 shadow-xl backdrop-blur">
+          <CardHeader className="border-b border-slate-100 bg-gradient-to-r from-slate-50 to-blue-50/70">
+            <div className="flex items-center gap-2 text-sm text-blue-700">
+              <Sparkles className="h-4 w-4" />
+              Starter Workflows
+            </div>
+            <CardTitle className="text-2xl text-slate-900">
+              Start with a working workflow instead of a blank canvas
+            </CardTitle>
+            <CardDescription className="max-w-3xl text-sm text-slate-600">
+              Pick a template to load nodes, prompts, and outputs in one step. You can edit everything after it lands on the canvas.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6 p-6">
+            <div className="grid gap-4 lg:grid-cols-3">
+              {templates.map((template) => (
+                <Card key={template.id} className="flex h-full flex-col border-slate-200 shadow-sm">
+                  <CardHeader className="space-y-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="text-3xl leading-none">{template.icon}</div>
+                      <Badge variant="outline" className="text-xs text-slate-600">
+                        {template.setupLabel}
+                      </Badge>
+                    </div>
+                    <div>
+                      <CardTitle className="text-lg text-slate-900">{template.name}</CardTitle>
+                      <CardDescription className="mt-2 text-sm text-slate-600">
+                        {template.description}
+                      </CardDescription>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="flex flex-1 flex-col justify-between gap-5">
+                    <div className="space-y-2">
+                      {template.highlights.map((highlight) => (
+                        <div key={highlight} className="text-sm text-slate-600">
+                          {highlight}
+                        </div>
+                      ))}
+                    </div>
+                    <Button onClick={() => onApplyTemplate(template.id)} className="w-full justify-between">
+                      Use Template
+                      <ArrowRight className="h-4 w-4" />
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-3">
+              <div className="text-sm text-slate-600">
+                Prefer to build from scratch? Keep the blank canvas and drag nodes from the left sidebar whenever you are ready.
+              </div>
+              <Button variant="outline" onClick={onDismiss}>
+                Continue with Blank Canvas
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default StarterWorkflowPanel;

--- a/src/data/starterWorkflowTemplates.ts
+++ b/src/data/starterWorkflowTemplates.ts
@@ -1,0 +1,238 @@
+import type { Workflow } from '../types';
+
+export interface StarterWorkflowTemplate {
+  id: string;
+  name: string;
+  description: string;
+  setupLabel: string;
+  highlights: string[];
+  icon: string;
+  workflow: Pick<Workflow, 'name' | 'description' | 'flow'>;
+}
+
+export const starterWorkflowTemplates: StarterWorkflowTemplate[] = [
+  {
+    id: 'prompt-assistant',
+    name: 'Prompt Assistant',
+    description: 'Take one text input, send it to the configured LLM, and download the answer.',
+    setupLabel: 'Requires LLM API key',
+    highlights: ['Fastest way to test your model setup', 'Good default for drafting and rewriting'],
+    icon: '🤖',
+    workflow: {
+      name: 'Prompt Assistant',
+      description: 'Simple input to LLM to output workflow.',
+      flow: {
+        nodes: [
+          {
+            id: 'input_prompt',
+            type: 'input',
+            position: { x: 120, y: 180 },
+            data: {
+              label: 'Prompt',
+              value: 'Summarize this note into three clear bullet points.',
+              inputType: 'text',
+              width: 220,
+              height: 160
+            }
+          },
+          {
+            id: 'llm_response',
+            type: 'llm',
+            position: { x: 450, y: 160 },
+            data: {
+              label: 'Generate Response',
+              systemPrompt: 'You are a practical writing assistant. Produce concise, readable output.',
+              prompt: 'Respond to the following request:',
+              temperature: 0.5,
+              model: 'gpt-5-nano',
+              width: 300,
+              height: 220
+            }
+          },
+          {
+            id: 'output_response',
+            type: 'output',
+            position: { x: 820, y: 180 },
+            data: {
+              label: 'Result',
+              format: 'markdown',
+              title: 'LLM Response',
+              fileName: 'prompt-assistant-result',
+              width: 240,
+              height: 180
+            }
+          }
+        ],
+        edges: [
+          {
+            id: 'conn_prompt_to_llm',
+            source: 'input_prompt',
+            target: 'llm_response',
+            sourceHandle: '0',
+            targetHandle: '0'
+          },
+          {
+            id: 'conn_llm_to_output',
+            source: 'llm_response',
+            target: 'output_response',
+            sourceHandle: '0',
+            targetHandle: '0'
+          }
+        ],
+        viewport: { x: 0, y: 0, zoom: 0.9 }
+      }
+    }
+  },
+  {
+    id: 'ai-writing-assistant',
+    name: 'Writing Assistant',
+    description: 'Turn a topic and keywords into an outline, then expand it into a full article.',
+    setupLabel: 'Requires LLM API key',
+    highlights: ['Shows multi-step chaining', 'Useful for blog drafts and briefing docs'],
+    icon: '✍️',
+    workflow: {
+      name: 'Writing Assistant',
+      description: 'Two-step article drafting workflow.',
+      flow: {
+        nodes: [
+          {
+            id: 'input_topic',
+            type: 'input',
+            position: { x: 50, y: 100 },
+            data: {
+              label: 'Article Topic',
+              value: 'The Future of Web Development',
+              inputType: 'text',
+              width: 200,
+              height: 150
+            }
+          },
+          {
+            id: 'input_keywords',
+            type: 'input',
+            position: { x: 50, y: 300 },
+            data: {
+              label: 'Keywords',
+              value: 'React, TypeScript, AI, automation',
+              inputType: 'text',
+              width: 200,
+              height: 150
+            }
+          },
+          {
+            id: 'combiner_outline',
+            type: 'text_combiner',
+            position: { x: 320, y: 200 },
+            data: {
+              label: 'Create Outline Request',
+              separator: '\n\nKeywords: ',
+              width: 220,
+              height: 180
+            }
+          },
+          {
+            id: 'llm_outline',
+            type: 'llm',
+            position: { x: 600, y: 200 },
+            data: {
+              label: 'Generate Outline',
+              systemPrompt: 'You are a professional content writer. Create detailed article outlines with engaging titles, clear structure, and comprehensive sections.',
+              prompt: 'Create a detailed article outline for the following topic and keywords:',
+              temperature: 0.7,
+              model: 'gpt-5-nano',
+              width: 320,
+              height: 240
+            }
+          },
+          {
+            id: 'llm_content',
+            type: 'llm',
+            position: { x: 980, y: 200 },
+            data: {
+              label: 'Write Article',
+              systemPrompt: 'You are an expert technical writer. Transform the provided outline into a well-structured, informative article. Use clear explanations, practical examples, and engaging language suitable for developers.',
+              prompt: 'Based on this outline, write a comprehensive article:',
+              temperature: 0.8,
+              model: 'gpt-5-nano',
+              width: 320,
+              height: 240
+            }
+          },
+          {
+            id: 'output_article',
+            type: 'output',
+            position: { x: 1350, y: 225 },
+            data: {
+              label: 'Final Article',
+              format: 'markdown',
+              title: 'Generated Article',
+              fileName: 'writing-assistant-article',
+              width: 250,
+              height: 180
+            }
+          }
+        ],
+        edges: [
+          { id: 'conn_1', source: 'input_topic', target: 'combiner_outline', sourceHandle: '0', targetHandle: '0' },
+          { id: 'conn_2', source: 'input_keywords', target: 'combiner_outline', sourceHandle: '0', targetHandle: '1' },
+          { id: 'conn_3', source: 'combiner_outline', target: 'llm_outline', sourceHandle: '0', targetHandle: '0' },
+          { id: 'conn_4', source: 'llm_outline', target: 'llm_content', sourceHandle: '0', targetHandle: '0' },
+          { id: 'conn_5', source: 'llm_content', target: 'output_article', sourceHandle: '0', targetHandle: '0' }
+        ],
+        viewport: { x: 0, y: 0, zoom: 0.8 }
+      }
+    }
+  },
+  {
+    id: 'simple-input-output',
+    name: 'Simple Input/Output',
+    description: 'Start with the smallest possible workflow and verify that data moves through the graph.',
+    setupLabel: 'No API key required',
+    highlights: ['Good for learning the editor', 'Works fully offline'],
+    icon: '🌱',
+    workflow: {
+      name: 'Simple Input/Output',
+      description: 'Minimal starter workflow.',
+      flow: {
+        nodes: [
+          {
+            id: 'input_1',
+            type: 'input',
+            position: { x: 100, y: 150 },
+            data: {
+              label: 'Input',
+              value: 'Hello, World!',
+              inputType: 'text',
+              width: 180,
+              height: 168
+            }
+          },
+          {
+            id: 'output_1',
+            type: 'output',
+            position: { x: 400, y: 150 },
+            data: {
+              label: 'Output',
+              format: 'text',
+              title: 'Result',
+              fileName: 'simple-output',
+              result: '',
+              width: 180,
+              height: 168
+            }
+          }
+        ],
+        edges: [
+          {
+            id: 'conn_1',
+            source: 'input_1',
+            target: 'output_1',
+            sourceHandle: '0',
+            targetHandle: '0'
+          }
+        ],
+        viewport: { x: 0, y: 0, zoom: 1 }
+      }
+    }
+  }
+];

--- a/src/services/workflowManagerService.test.ts
+++ b/src/services/workflowManagerService.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import workflowManagerService from './workflowManagerService';
 import StorageService from './storageService';
 import { Workflow } from '../types';
+import { starterWorkflowTemplates } from '../data/starterWorkflowTemplates';
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -166,5 +167,35 @@ describe('workflowManagerService', () => {
     
     workflowManagerService.setCurrentWorkflowId('test-id');
     expect(workflowManagerService.getCurrentWorkflowId()).toBe('test-id');
+  });
+
+  it('should apply a starter template onto an existing workflow', () => {
+    const savedWorkflows: Record<string, Workflow> = {};
+    let currentId: string | null = null;
+
+    vi.spyOn(StorageService, 'getWorkflows').mockImplementation(() => savedWorkflows);
+    vi.spyOn(StorageService, 'setWorkflows').mockImplementation((workflows) => {
+      Object.assign(savedWorkflows, workflows);
+      return true;
+    });
+    vi.spyOn(StorageService, 'setCurrentWorkflowId').mockImplementation((id) => {
+      currentId = id;
+      return true;
+    });
+    vi.spyOn(StorageService, 'getCurrentWorkflowId').mockImplementation(() => currentId);
+
+    const blankWorkflow = workflowManagerService.createNewWorkflow('Untitled Workflow');
+    workflowManagerService.saveWorkflow(blankWorkflow);
+
+    const updatedWorkflow = workflowManagerService.applyTemplateToWorkflow(
+      blankWorkflow.id,
+      starterWorkflowTemplates[0].workflow
+    );
+
+    expect(updatedWorkflow).not.toBeNull();
+    expect(updatedWorkflow?.id).toBe(blankWorkflow.id);
+    expect(updatedWorkflow?.name).toBe('Prompt Assistant');
+    expect(updatedWorkflow?.flow.nodes.length).toBeGreaterThan(0);
+    expect(workflowManagerService.getCurrentWorkflowId()).toBe(blankWorkflow.id);
   });
 });

--- a/src/services/workflowManagerService.ts
+++ b/src/services/workflowManagerService.ts
@@ -17,6 +17,10 @@ function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 }
 
+function cloneWorkflowData<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
 /**
  * Load a sample workflow from the public directory
  */
@@ -215,6 +219,49 @@ class WorkflowManagerService {
       },
       lastModified: new Date().toISOString(),
     };
+  }
+
+  /**
+   * Create a brand-new workflow from a starter template
+   */
+  createWorkflowFromTemplate(
+    template: Pick<Workflow, 'name' | 'description' | 'flow'>,
+    name: string = template.name
+  ): Workflow {
+    return {
+      id: generateId(),
+      name,
+      description: template.description,
+      flow: cloneWorkflowData(template.flow),
+      lastModified: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Apply a starter template onto an existing workflow
+   */
+  applyTemplateToWorkflow(
+    workflowId: string,
+    template: Pick<Workflow, 'name' | 'description' | 'flow'>,
+    name: string = template.name
+  ): Workflow | null {
+    const existingWorkflow = this.getWorkflow(workflowId);
+    if (!existingWorkflow) {
+      logger.warn(`Cannot apply template to missing workflow: ${workflowId}`);
+      return null;
+    }
+
+    const updatedWorkflow: Workflow = {
+      ...existingWorkflow,
+      name,
+      description: template.description,
+      flow: cloneWorkflowData(template.flow),
+      lastModified: new Date().toISOString(),
+    };
+
+    this.saveWorkflow(updatedWorkflow);
+    this.setCurrentWorkflowId(updatedWorkflow.id);
+    return updatedWorkflow;
   }
   /**
    * Reset the service state for testing.


### PR DESCRIPTION
## What changed
- added an in-app starter workflow panel for empty canvases
- bundled starter templates in source so onboarding works without fetching public sample files
- added workflow manager helpers to create or apply templates safely
- covered template application with a focused unit test

## Why
The first-run experience still dropped users into an empty workflow with no guidance. That made the app feel unfinished even after the earlier quality fixes.

## Impact
- first-time users can load a usable workflow in one click
- starter flows now work in bundled builds without depending on runtime fetches
- blank workflows are easier to recover from because the template picker appears whenever the canvas is empty

## Root cause
Onboarding depended on an empty default workflow and an unused sample-loading path. There was no guided bridge between opening the editor and getting to a working graph.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`
