### PR TITLE
[codex] strengthen template discovery

### DIFF
--- a/src/components/ReactFlowEditor/index.tsx
+++ b/src/components/ReactFlowEditor/index.tsx
@@ -486,6 +486,27 @@ const ReactFlowEditor = ({ selectedNode, editingNode, onSelectedNodeChange, onEd
     setWorkflows(Object.values(workflowsData));
   }, [currentWorkflow]);
 
+  const handleCreateStarterWorkflow = useCallback((templateId: string) => {
+    const template = starterWorkflowTemplates.find(entry => entry.id === templateId);
+    if (!template) {
+      toast.error('スターターテンプレートが見つかりませんでした');
+      return;
+    }
+
+    const createdWorkflow = workflowManagerService.createWorkflowFromTemplate(template.workflow);
+    workflowManagerService.saveWorkflow(createdWorkflow);
+    workflowManagerService.setCurrentWorkflowId(createdWorkflow.id);
+
+    loadWorkflow(createdWorkflow.id);
+    setCurrentWorkflow(createdWorkflow);
+    setHasUnsavedChanges(false);
+    setStarterPanelDismissed(false);
+
+    const workflowsData = workflowManagerService.getWorkflows();
+    setWorkflows(Object.values(workflowsData));
+    toast.success(`"${template.name}" を新しいワークフローとして作成しました`);
+  }, [loadWorkflow]);
+
   const handleApplyStarterTemplate = useCallback((templateId: string) => {
     const template = starterWorkflowTemplates.find(entry => entry.id === templateId);
     if (!template) {
@@ -819,6 +840,7 @@ const ReactFlowEditor = ({ selectedNode, editingNode, onSelectedNodeChange, onEd
         onStop={handleResetExecution}
         isExecuting={executionState?.running}
         onOpenCopilot={onOpenCopilot}
+        onCreateFromTemplate={handleCreateStarterWorkflow}
       />
       <HandleLabelsProvider showHandleLabels={showHandleLabels}>
         <ReactFlow

--- a/src/components/StarterWorkflowPanel.tsx
+++ b/src/components/StarterWorkflowPanel.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
 import type { StarterWorkflowTemplate } from '../data/starterWorkflowTemplates';
 
@@ -12,74 +13,108 @@ interface StarterWorkflowPanelProps {
   templates: StarterWorkflowTemplate[];
   onApplyTemplate: (templateId: string) => void;
   onDismiss: () => void;
+  variant?: 'overlay' | 'inline';
+  title?: string;
+  description?: string;
+  badgeLabel?: string;
+  applyLabel?: string;
+  dismissLabel?: string;
+  dismissDescription?: string;
 }
 
 const StarterWorkflowPanel = ({
   templates,
   onApplyTemplate,
   onDismiss,
+  variant = 'overlay',
+  title = 'Start with a working workflow instead of a blank canvas',
+  description = 'Pick a template to load nodes, prompts, and outputs in one step. You can edit everything after it lands on the canvas.',
+  badgeLabel = 'Starter Workflows',
+  applyLabel = 'Use Template',
+  dismissLabel = 'Continue with Blank Canvas',
+  dismissDescription = 'Prefer to build from scratch? Keep the blank canvas and drag nodes from the left sidebar whenever you are ready.',
 }: StarterWorkflowPanelProps) => {
+  const isOverlay = variant === 'overlay';
+
+  const panelContent = (
+    <Card
+      className={cn(
+        'border-slate-200 bg-white/95 backdrop-blur',
+        isOverlay ? 'shadow-xl' : 'border-0 bg-transparent shadow-none'
+      )}
+    >
+      <CardHeader
+        className={cn(
+          'bg-gradient-to-r from-slate-50 to-blue-50/70',
+          isOverlay ? 'border-b border-slate-100' : 'px-0 pt-0 pb-6'
+        )}
+      >
+        <div className="flex items-center gap-2 text-sm text-blue-700">
+          <Sparkles className="h-4 w-4" />
+          {badgeLabel}
+        </div>
+        <CardTitle className="text-2xl text-slate-900">
+          {title}
+        </CardTitle>
+        <CardDescription className="max-w-3xl text-sm text-slate-600">
+          {description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className={cn('space-y-6', isOverlay ? 'p-6' : 'px-0 pb-0')}>
+        <div className="grid gap-4 lg:grid-cols-3">
+          {templates.map((template) => (
+            <Card key={template.id} className="flex h-full flex-col border-slate-200 shadow-sm">
+              <CardHeader className="space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="text-3xl leading-none">{template.icon}</div>
+                  <Badge variant="outline" className="text-xs text-slate-600">
+                    {template.setupLabel}
+                  </Badge>
+                </div>
+                <div>
+                  <CardTitle className="text-lg text-slate-900">{template.name}</CardTitle>
+                  <CardDescription className="mt-2 text-sm text-slate-600">
+                    {template.description}
+                  </CardDescription>
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col justify-between gap-5">
+                <div className="space-y-2">
+                  {template.highlights.map((highlight) => (
+                    <div key={highlight} className="text-sm text-slate-600">
+                      {highlight}
+                    </div>
+                  ))}
+                </div>
+                <Button onClick={() => onApplyTemplate(template.id)} className="w-full justify-between">
+                  {applyLabel}
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-3">
+          <div className="text-sm text-slate-600">
+            {dismissDescription}
+          </div>
+          <Button variant="outline" onClick={onDismiss}>
+            {dismissLabel}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  if (!isOverlay) {
+    return panelContent;
+  }
+
   return (
     <div className="absolute inset-0 z-40 pointer-events-none px-6 pt-24 pb-8">
       <div className="mx-auto max-w-6xl pointer-events-auto">
-        <Card className="border-slate-200 bg-white/95 shadow-xl backdrop-blur">
-          <CardHeader className="border-b border-slate-100 bg-gradient-to-r from-slate-50 to-blue-50/70">
-            <div className="flex items-center gap-2 text-sm text-blue-700">
-              <Sparkles className="h-4 w-4" />
-              Starter Workflows
-            </div>
-            <CardTitle className="text-2xl text-slate-900">
-              Start with a working workflow instead of a blank canvas
-            </CardTitle>
-            <CardDescription className="max-w-3xl text-sm text-slate-600">
-              Pick a template to load nodes, prompts, and outputs in one step. You can edit everything after it lands on the canvas.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6 p-6">
-            <div className="grid gap-4 lg:grid-cols-3">
-              {templates.map((template) => (
-                <Card key={template.id} className="flex h-full flex-col border-slate-200 shadow-sm">
-                  <CardHeader className="space-y-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="text-3xl leading-none">{template.icon}</div>
-                      <Badge variant="outline" className="text-xs text-slate-600">
-                        {template.setupLabel}
-                      </Badge>
-                    </div>
-                    <div>
-                      <CardTitle className="text-lg text-slate-900">{template.name}</CardTitle>
-                      <CardDescription className="mt-2 text-sm text-slate-600">
-                        {template.description}
-                      </CardDescription>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="flex flex-1 flex-col justify-between gap-5">
-                    <div className="space-y-2">
-                      {template.highlights.map((highlight) => (
-                        <div key={highlight} className="text-sm text-slate-600">
-                          {highlight}
-                        </div>
-                      ))}
-                    </div>
-                    <Button onClick={() => onApplyTemplate(template.id)} className="w-full justify-between">
-                      Use Template
-                      <ArrowRight className="h-4 w-4" />
-                    </Button>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-
-            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-3">
-              <div className="text-sm text-slate-600">
-                Prefer to build from scratch? Keep the blank canvas and drag nodes from the left sidebar whenever you are ready.
-              </div>
-              <Button variant="outline" onClick={onDismiss}>
-                Continue with Blank Canvas
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        {panelContent}
       </div>
     </div>
   );

--- a/src/components/WorkflowToolbar.tsx
+++ b/src/components/WorkflowToolbar.tsx
@@ -18,7 +18,9 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 
+import { starterWorkflowTemplates } from '@/data/starterWorkflowTemplates';
 import { Workflow } from '@/types';
+import StarterWorkflowPanel from './StarterWorkflowPanel';
 import { useDebuggerStore } from '../store/debuggerStore';
 import { cn } from '../lib/utils';
 
@@ -39,6 +41,7 @@ interface WorkflowToolbarProps {
   onStepForward: () => void;
   isExecuting: boolean;
   onOpenCopilot?: () => void;
+  onCreateFromTemplate?: (templateId: string) => void;
 }
 
 const WorkflowToolbar = ({
@@ -57,12 +60,14 @@ const WorkflowToolbar = ({
   onStop,
   onStepForward,
   isExecuting = false,
-  onOpenCopilot
+  onOpenCopilot,
+  onCreateFromTemplate
 }: WorkflowToolbarProps) => {
   const [isRenaming, setIsRenaming] = useState(false);
   const [newName, setNewName] = useState('');
   const [showLoadDialog, setShowLoadDialog] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showTemplatesDialog, setShowTemplatesDialog] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
 
@@ -118,6 +123,11 @@ const WorkflowToolbar = ({
     onLoad?.(workflowId);
     setShowLoadDialog(false);
     toast.success('Workflow loaded');
+  };
+
+  const handleCreateFromTemplate = (templateId: string) => {
+    onCreateFromTemplate?.(templateId);
+    setShowTemplatesDialog(false);
   };
 
   const handleSave = () => {
@@ -295,6 +305,35 @@ const WorkflowToolbar = ({
                   Create Workflow
                 </Button>
               </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog open={showTemplatesDialog} onOpenChange={setShowTemplatesDialog}>
+            <DialogTrigger asChild>
+              <Button size="sm" variant="outline">
+                <Sparkles className="h-4 w-4 mr-1.5" />
+                Templates
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-5xl">
+              <DialogHeader className="sr-only">
+                <DialogTitle>Browse Starter Templates</DialogTitle>
+                <DialogDescription>
+                  Create a new workflow from a starter template without overwriting your current canvas.
+                </DialogDescription>
+              </DialogHeader>
+              <StarterWorkflowPanel
+                templates={starterWorkflowTemplates}
+                onApplyTemplate={handleCreateFromTemplate}
+                onDismiss={() => setShowTemplatesDialog(false)}
+                variant="inline"
+                badgeLabel="Starter Templates"
+                title="Create a workflow from a starter template"
+                description="Use a ready-made workflow whenever you want a head start. Your current canvas stays untouched."
+                applyLabel="Create Workflow"
+                dismissLabel="Close Browser"
+                dismissDescription="Prefer to start empty? Close this browser and use New to create a blank workflow."
+              />
             </DialogContent>
           </Dialog>
 

--- a/src/services/workflowManagerService.test.ts
+++ b/src/services/workflowManagerService.test.ts
@@ -198,4 +198,34 @@ describe('workflowManagerService', () => {
     expect(updatedWorkflow?.flow.nodes.length).toBeGreaterThan(0);
     expect(workflowManagerService.getCurrentWorkflowId()).toBe(blankWorkflow.id);
   });
+
+  it('should create a new workflow from a starter template without mutating the template', () => {
+    const savedWorkflows: Record<string, Workflow> = {};
+
+    vi.spyOn(StorageService, 'getWorkflows').mockImplementation(() => savedWorkflows);
+    vi.spyOn(StorageService, 'setWorkflows').mockImplementation((workflows) => {
+      Object.assign(savedWorkflows, workflows);
+      return true;
+    });
+
+    const template = starterWorkflowTemplates[2];
+    const createdWorkflow = workflowManagerService.createWorkflowFromTemplate(
+      template.workflow,
+      'Template Copy'
+    );
+
+    workflowManagerService.saveWorkflow(createdWorkflow);
+
+    expect(createdWorkflow.id).toBeDefined();
+    expect(createdWorkflow.name).toBe('Template Copy');
+    expect(createdWorkflow.flow).not.toBe(template.workflow.flow);
+    expect(createdWorkflow.flow.nodes).toEqual(template.workflow.flow.nodes);
+
+    const createdInputNode = createdWorkflow.flow.nodes[0] as { data: { label: string } };
+    const templateInputNode = template.workflow.flow.nodes[0] as { data: { label: string } };
+
+    createdInputNode.data.label = 'Changed';
+
+    expect(templateInputNode.data.label).toBe('Input');
+  });
 });


### PR DESCRIPTION
## What changed
- added a persistent `Templates` entry point in the workflow toolbar so starter workflows are discoverable beyond the empty-canvas state
- reused `StarterWorkflowPanel` in both overlay and dialog contexts with configurable copy and actions
- wired template selection in the toolbar to create a brand-new workflow from the selected starter template
- added a workflow manager test that verifies template-based workflow creation deep-clones flow data

## Why
Starter templates were only visible on a brand-new blank canvas. Once a user had an existing workflow open, there was no clear way to discover or start from templates without manually creating a fresh empty workflow first.

## Impact
Users can now browse starter templates at any time without overwriting the current canvas, which makes the onboarding path easier to rediscover and lowers the cost of trying a template mid-session.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`