### PR TITLE
[codex] split production vendor chunks

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,44 @@ import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
+const MANUAL_CHUNK_GROUPS = [
+  {
+    name: 'vendor-react',
+    packages: ['react', 'react-dom', 'react-router', 'react-router-dom', 'scheduler'],
+  },
+  {
+    name: 'vendor-flow',
+    packages: ['@xyflow/react'],
+  },
+  {
+    name: 'vendor-radix',
+    packages: ['@radix-ui/'],
+  },
+  {
+    name: 'vendor-ui',
+    packages: ['framer-motion', 'recharts', 'lucide-react', 'embla-carousel-react', 'vaul', 'cmdk'],
+  },
+  {
+    name: 'vendor-data',
+    packages: ['ajv', 'ajv-formats', 'zod', 'dexie', 'date-fns', 'jexl', 'croner'],
+  },
+]
+
+function getManualChunkName(id) {
+  if (!id.includes('node_modules')) {
+    return undefined
+  }
+
+  const normalizedId = id.replace(/\\/g, '/')
+
+  for (const group of MANUAL_CHUNK_GROUPS) {
+    if (group.packages.some((pkg) => normalizedId.includes(`/node_modules/${pkg}`))) {
+      return group.name
+    }
+  }
+
+  return 'vendor-misc'
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -23,7 +61,13 @@ export default defineConfig(({ mode }) => {
           manualChunks: undefined,
         }
       }
-    } : {}
+    } : {
+      rollupOptions: {
+        output: {
+          manualChunks: getManualChunkName,
+        },
+      },
+    }
   }
 })
 


### PR DESCRIPTION
## What changed
- added a `manualChunks` strategy to the production Vite build
- grouped major dependency families into dedicated vendor chunks instead of emitting a single oversized JavaScript bundle
- kept offline builds unchanged by preserving `inlineDynamicImports` for that mode

## Why
The production build was emitting a single `index` bundle above Vite's chunk warning threshold, which produced noisy build output and made it harder to reason about bundle growth.

## Impact
The main production bundle is now split into smaller vendor chunks, which removes the chunk-size warning and gives us clearer bundle boundaries for future tuning.

## Validation
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`

## Notes
- A separate Vite warning still remains for `src/components/nodes/index.ts` because it is imported both statically and dynamically. That is not a chunk-size warning and would require import-graph cleanup as a follow-up.