### PR TITLE
[codex] split execution node registry

### DIFF
--- a/src/components/nodes/executionRegistry.ts
+++ b/src/components/nodes/executionRegistry.ts
@@ -1,0 +1,47 @@
+import type { ExtendedNodeDefinition } from './types';
+
+import ArrayOperationsNode from './ArrayOperationsNode';
+import CodeExecutionNode from './CodeExecutionNode';
+import DataTransformNode from './DataTransformNode';
+import HTTPRequestNode from './HTTPRequestNode';
+import IfNode from './IfNode';
+import InputNode from './InputNode';
+import JSONTransformNode from './JSONTransformNode';
+import LLMNode from './LLMNode';
+import OutputNode from './OutputNode';
+import ScheduleNode from './ScheduleNode';
+import StructuredExtractionNode from './StructuredExtractionNode';
+import StructuredExtractionValidatorNode from './StructuredExtractionValidatorNode';
+import TextCombinerNode from './TextCombinerNode';
+import TimestampNode from './TimestampNode';
+import VariableSetNode from './VariableSetNode';
+import WebAPINode from './WebAPINode';
+import WebSearchNode from './WebSearchNode';
+import WhileNode from './WhileNode';
+import WorkflowNode from './WorkflowNode';
+
+// Runtime-only registry to keep the execution service's dynamic import separate
+// from the UI-facing nodes index, which is statically imported across the app.
+export const nodeTypes: Record<string, ExtendedNodeDefinition> = {
+  input: InputNode,
+  output: OutputNode,
+  llm: LLMNode,
+  text_combiner: TextCombinerNode,
+  structured_extraction: StructuredExtractionNode,
+  schema_validator: StructuredExtractionValidatorNode,
+  json_transform: JSONTransformNode,
+  array_operations: ArrayOperationsNode,
+  data_transform: DataTransformNode,
+  if: IfNode,
+  while: WhileNode,
+  variable_set: VariableSetNode,
+  schedule: ScheduleNode,
+  timestamp: TimestampNode,
+  http_request: HTTPRequestNode,
+  web_search: WebSearchNode,
+  code_execution: CodeExecutionNode,
+  web_api: WebAPINode,
+  workflow: WorkflowNode,
+};
+
+export default nodeTypes;

--- a/src/services/nodeExecutionService.ts
+++ b/src/services/nodeExecutionService.ts
@@ -106,7 +106,7 @@ export class NodeExecutionService {
     if (nodeTypes) {
       this.nodeTypesRegistry = nodeTypes;
     } else if (Object.keys(this.nodeTypesRegistry).length === 0) {
-      const { nodeTypes: loadedNodeTypes } = await import('../components/nodes/index');
+      const { nodeTypes: loadedNodeTypes } = await import('../components/nodes/executionRegistry');
       this.nodeTypesRegistry = loadedNodeTypes;
     }
 


### PR DESCRIPTION
## What changed
- added a dedicated `executionRegistry` module for the workflow runtime
- switched `nodeExecutionService` to dynamically import the runtime-only registry instead of the UI-facing `src/components/nodes/index.ts`

## Why
Vite was warning that `src/components/nodes/index.ts` was being imported both statically and dynamically. The dynamic import was only there as a runtime fallback for execution, while the UI imports the index statically across the app.

## Impact
The mixed static/dynamic import warning is gone, and the execution service still keeps its lazy fallback path without pulling the UI index into that import graph.

## Validation
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`