### PR TITLE
[codex] add research monitoring workflows

### DIFF
--- a/src/components/ReactFlowEditor/nodes/LLMNodeComponent.tsx
+++ b/src/components/ReactFlowEditor/nodes/LLMNodeComponent.tsx
@@ -9,6 +9,11 @@ import CustomNode from './CustomNode';
 const LLMNodeComponent = ({ id, data }: any) => {
   const updateNodeData = useReactFlowStore((state: any) => state.updateNodeData);
 
+  const onPromptChange = (evt: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = evt.target.value;
+    updateNodeData(id, { prompt: newValue });
+  };
+
   const onSystemPromptChange = (evt: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = evt.target.value;
     updateNodeData(id, { systemPrompt: newValue });
@@ -25,6 +30,17 @@ const LLMNodeComponent = ({ id, data }: any) => {
   return (
     <CustomNode data={nodeDataWithHandles} id={id}>
       <div className="space-y-3">
+        <div>
+          <label className="text-xs text-gray-500 block mb-1">Prompt Prefix</label>
+          <Textarea
+            value={data.prompt || ''}
+            onChange={onPromptChange}
+            className="nodrag text-xs resize-both"
+            style={{ resize: 'both', overflow: 'auto', minWidth: '200px', minHeight: '72px' }}
+            placeholder="Summarize the input into a dated research digest with links and key takeaways..."
+            rows={3}
+          />
+        </div>
         <div>
           <label className="text-xs text-gray-500 block mb-1">System Prompt</label>
           <Textarea

--- a/src/components/ReactFlowEditor/nodes/ScheduleNodeComponent.tsx
+++ b/src/components/ReactFlowEditor/nodes/ScheduleNodeComponent.tsx
@@ -1,11 +1,14 @@
 import React, { useCallback, memo } from 'react';
 
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
 
+import StorageService from '../../../services/storageService';
 import schedulerService, { SchedulerService } from '../../../services/schedulerService';
+import useReactFlowStore from '../../../store/reactFlowStore';
+
 import CustomNode from './CustomNode';
 
 interface ScheduleNodeComponentProps {
@@ -14,29 +17,49 @@ interface ScheduleNodeComponentProps {
 }
 
 const ScheduleNodeComponent: React.FC<ScheduleNodeComponentProps> = ({ id, data }) => {
-  // イベントハンドラー
+  const updateNodeData = useReactFlowStore((state: any) => state.updateNodeData);
+  const cronPresets = SchedulerService.getCronPresets();
+
   const onScheduleNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    // Handle schedule name change
-  }, []);
+    updateNodeData(id, { scheduleName: e.target.value });
+  }, [id, updateNodeData]);
 
   const onCronExpressionChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    // Handle cron expression change
-  }, []);
+    updateNodeData(id, { cronExpression: e.target.value });
+  }, [id, updateNodeData]);
 
   const onTimeoutChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    // Handle timeout change
-  }, []);
+    const parsed = parseInt(e.target.value, 10);
+    updateNodeData(id, { timeoutMinutes: Number.isNaN(parsed) ? 30 : parsed });
+  }, [id, updateNodeData]);
 
   const onEnabledChange = useCallback((checked: boolean) => {
-    // Handle enabled change
-  }, []);
+    updateNodeData(id, { enabled: checked });
+  }, [id, updateNodeData]);
+
+  const applyPreset = useCallback((cronExpression: string) => {
+    updateNodeData(id, { cronExpression });
+  }, [id, updateNodeData]);
 
   const getNextExecution = () => {
-    // Calculate next execution time
-    return null;
+    const workflowId = StorageService.getCurrentWorkflowId();
+    if (!workflowId || !data.enabled) {
+      return null;
+    }
+
+    const nextExecution = schedulerService.getNextExecution(workflowId);
+    if (!nextExecution) {
+      return null;
+    }
+
+    return nextExecution.toLocaleString('ja-JP', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
   };
 
-  // Cron式の説明を生成
   const getCronDescription = () => {
     if (!data.cronExpression) return '';
     return SchedulerService.humanReadableCron(data.cronExpression);
@@ -45,7 +68,6 @@ const ScheduleNodeComponent: React.FC<ScheduleNodeComponentProps> = ({ id, data 
   return (
     <CustomNode data={data} id={id}>
       <div className="space-y-3 min-w-[280px]">
-        {/* スケジュール名 */}
         <div className="space-y-1">
           <Label htmlFor={`schedule-name-${id}`} className="text-xs font-medium">
             スケジュール名
@@ -55,18 +77,17 @@ const ScheduleNodeComponent: React.FC<ScheduleNodeComponentProps> = ({ id, data 
             value={data.scheduleName || ''}
             onChange={onScheduleNameChange}
             className="nodrag text-xs"
-            placeholder="例: Daily Report"
+            placeholder="例: Morning Research Digest"
           />
         </div>
 
-        {/* Cron式 */}
-        <div className="space-y-1">
+        <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Label htmlFor={`cron-${id}`} className="text-xs font-medium">
               Cron式
             </Label>
             <div className="text-xs text-muted-foreground font-mono">
-              分 時 日 月 曜日<br/>
+              分 時 日 月 曜日<br />
               *  *  *  *  *
             </div>
           </div>
@@ -75,7 +96,7 @@ const ScheduleNodeComponent: React.FC<ScheduleNodeComponentProps> = ({ id, data 
             value={data.cronExpression || ''}
             onChange={onCronExpressionChange}
             className="nodrag text-xs font-mono"
-            placeholder="0 9 * * *"
+            placeholder="0 9 * * 1-5"
           />
           {data.cronExpression && (
             <div className="text-xs text-muted-foreground">
@@ -84,7 +105,21 @@ const ScheduleNodeComponent: React.FC<ScheduleNodeComponentProps> = ({ id, data 
           )}
         </div>
 
-        {/* タイムアウト設定 */}
+        <div className="flex flex-wrap gap-1">
+          {cronPresets.slice(0, 5).map((preset) => (
+            <Button
+              key={preset.value}
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-[11px]"
+              onClick={() => applyPreset(preset.value)}
+            >
+              {preset.label}
+            </Button>
+          ))}
+        </div>
+
         <div className="space-y-1">
           <Label htmlFor={`timeout-${id}`} className="text-xs font-medium">
             タイムアウト (分)
@@ -100,7 +135,6 @@ const ScheduleNodeComponent: React.FC<ScheduleNodeComponentProps> = ({ id, data 
           />
         </div>
 
-        {/* 有効/無効スイッチ */}
         <div className="flex items-center justify-between space-x-2">
           <Label htmlFor={`enabled-${id}`} className="text-xs font-medium">
             スケジュール有効
@@ -112,7 +146,6 @@ const ScheduleNodeComponent: React.FC<ScheduleNodeComponentProps> = ({ id, data 
           />
         </div>
 
-        {/* ステータス表示 */}
         <div className="pt-2 border-t border-gray-200">
           <div className="space-y-1 text-xs">
             <div className="flex justify-between">
@@ -121,20 +154,23 @@ const ScheduleNodeComponent: React.FC<ScheduleNodeComponentProps> = ({ id, data 
                 {data.enabled ? '有効' : '無効'}
               </span>
             </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">タイムゾーン:</span>
+              <span>{data.timezone || 'Asia/Tokyo'}</span>
+            </div>
             {data.enabled && (
-              <div className="flex justify-between">
+              <div className="flex justify-between gap-2">
                 <span className="text-muted-foreground">次回実行:</span>
-                <span className="text-blue-600 text-xs">
-                  {getNextExecution() || '計算中...'}
+                <span className="text-blue-600 text-xs text-right">
+                  {getNextExecution() || '保存後に更新'}
                 </span>
               </div>
             )}
           </div>
         </div>
 
-        {/* ヘルプテキスト */}
         <div className="text-xs text-muted-foreground bg-gray-50 p-2 rounded">
-          💡 このノードはワークフロー全体をスケジュール実行します。エッジ接続は不要です。
+          💡 このノードはワークフロー全体をスケジュール実行します。ニュース監視なら平日朝のcronを入れておくと運用しやすいです。
         </div>
       </div>
     </CustomNode>

--- a/src/components/ReactFlowEditor/nodes/WebSearchNodeComponent.tsx
+++ b/src/components/ReactFlowEditor/nodes/WebSearchNodeComponent.tsx
@@ -86,7 +86,7 @@ const WebSearchNodeComponent = memo(({ data = {}, id }: WebSearchNodeComponentPr
         <div className="space-y-2">
           <Label className="text-xs text-gray-600">検索クエリ</Label>
           <Textarea
-            placeholder="検索したい内容を入力..."
+            placeholder="例: 生成AI 業界動向 OR LLM regulation"
             value={data.query || ''}
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => updateData('query', e.target.value)}
             className="text-sm min-h-[60px] nodrag"
@@ -143,6 +143,36 @@ const WebSearchNodeComponent = memo(({ data = {}, id }: WebSearchNodeComponentPr
                 </SelectContent>
               </Select>
             </div>
+            <div className="space-y-2">
+              <Label className="text-xs text-gray-600">対象サイト</Label>
+              <Textarea
+                placeholder={'techcrunch.com\nopenai.com\nwww.theverge.com'}
+                value={data.siteFilters || ''}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => updateData('siteFilters', e.target.value)}
+                className="text-xs min-h-[72px] nodrag"
+              />
+              <div className="text-[11px] text-muted-foreground">
+                1行またはカンマ区切りで指定すると `site:` 条件として検索に追加されます。
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs text-gray-600 flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                過去何日を対象にするか
+              </Label>
+              <Input
+                type="number"
+                min="1"
+                max="365"
+                value={data.freshnessDays ?? ''}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  const rawValue = e.target.value.trim();
+                  updateData('freshnessDays', rawValue ? Math.max(1, parseInt(rawValue, 10) || 1) : undefined);
+                }}
+                className="text-xs h-8 nodrag"
+                placeholder="例: 3"
+              />
+            </div>
             <div className="flex items-center justify-between">
               <Label htmlFor="safeSearch" className="text-xs flex items-center gap-1">
                 <Shield className="w-3 h-3" />
@@ -183,6 +213,16 @@ const WebSearchNodeComponent = memo(({ data = {}, id }: WebSearchNodeComponentPr
               <Badge variant="outline" className="text-xs">
                 <Clock className="w-3 h-3 mr-1" />
                 Cache
+              </Badge>
+            )}
+            {!!data.siteFilters?.trim() && (
+              <Badge variant="outline" className="text-xs">
+                Sites
+              </Badge>
+            )}
+            {!!data.freshnessDays && (
+              <Badge variant="outline" className="text-xs">
+                {data.freshnessDays}d
               </Badge>
             )}
           </div>

--- a/src/components/nodes/LLMNode.test.ts
+++ b/src/components/nodes/LLMNode.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../services/llmService', () => ({
+  default: {
+    sendMessage: vi.fn(),
+    loadSettings: vi.fn(() => ({
+      apiKey: 'sk-test',
+      baseUrl: '',
+      maxTokens: 2048,
+    })),
+  },
+}));
+
+import llmService from '../../services/llmService';
+import { buildFinalPrompt, LLMNode } from './LLMNode';
+
+describe('LLMNode', () => {
+  beforeEach(() => {
+    vi.mocked(llmService.sendMessage).mockReset();
+    vi.mocked(llmService.loadSettings).mockClear();
+  });
+
+  it('builds a final prompt with prefix and serialized structured inputs', () => {
+    const prompt = buildFinalPrompt(
+      [
+        [{ title: 'OpenAI update', url: 'https://openai.com' }],
+        { totalResults: 1 },
+      ],
+      'Summarize these results'
+    );
+
+    expect(prompt).toContain('Summarize these results');
+    expect(prompt).toContain('"title": "OpenAI update"');
+    expect(prompt).toContain('"totalResults": 1');
+  });
+
+  it('sends serialized object inputs to the LLM service', async () => {
+    vi.mocked(llmService.sendMessage).mockResolvedValue('digest');
+
+    const result = await LLMNode.execute(
+      {
+        id: 'llm-1',
+        type: 'llm',
+        position: { x: 0, y: 0 },
+        data: {
+          prompt: 'Summarize into a digest',
+          model: 'gpt-5-nano',
+        },
+      },
+      {
+        input: [{ title: 'OpenAI update' }],
+      }
+    );
+
+    expect(result).toBe('digest');
+    expect(llmService.sendMessage).toHaveBeenCalledWith(
+      expect.stringContaining('"title": "OpenAI update"'),
+      null,
+      expect.objectContaining({
+        model: 'gpt-5-nano',
+        provider: 'openai',
+      })
+    );
+  });
+});

--- a/src/components/nodes/LLMNode.ts
+++ b/src/components/nodes/LLMNode.ts
@@ -10,6 +10,34 @@ declare global {
   }
 }
 
+export function serializePromptInput(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value, null, 2);
+  }
+
+  return String(value);
+}
+
+export function buildFinalPrompt(inputValues: unknown[], promptPrefix?: string): string {
+  const promptParts = inputValues
+    .map(serializePromptInput)
+    .filter((value) => value.trim().length > 0);
+
+  if (promptPrefix && promptPrefix.trim()) {
+    promptParts.unshift(promptPrefix.trim());
+  }
+
+  return promptParts.join('\n\n');
+}
+
 /**
  * LLM生成ノードの実行処理
  * @param {Object} node - ノードオブジェクト
@@ -31,7 +59,7 @@ async function executeLLMNode(node: WorkflowNode, inputs: NodeInputs, context?: 
     throw new Error('LLMノードに入力がありません');
   }
   
-  const finalPrompt = inputValues.join('\n');
+  const finalPrompt = buildFinalPrompt(inputValues, nodeData.prompt);
   
   try {
     // デバッグ情報をログに記録
@@ -107,6 +135,7 @@ export const LLMNode = createNodeDefinition(
   {
     temperature: 1.0,
     model: 'gpt-5-nano',
+    prompt: '',
     systemPrompt: '',
     maxTokens: 50000
   },

--- a/src/components/nodes/ScheduleNode.ts
+++ b/src/components/nodes/ScheduleNode.ts
@@ -1,6 +1,7 @@
 import { createNodeDefinition } from './types';
 import type { WorkflowNode, NodeInputs, INodeExecutionContext, NodeOutput } from '../../types';
 import schedulerService from '../../services/schedulerService';
+import StorageService from '../../services/storageService';
 
 /**
  * スケジュールノードの実行処理
@@ -12,17 +13,20 @@ import schedulerService from '../../services/schedulerService';
  * @returns {Promise<string>} スケジュール情報
  */
 async function executeScheduleNode(node: WorkflowNode, inputs: NodeInputs, context?: INodeExecutionContext): Promise<NodeOutput> {
-  const { cronExpression, scheduleName, enabled }: any = node.data;
+  const { cronExpression, scheduleName, enabled, timezone, timeoutMinutes }: any = node.data;
   
   context?.addLog('info', 'スケジュールトリガーノード情報を確認中', node.id, { 
     cronExpression, 
     scheduleName, 
-    enabled 
+    enabled,
+    timezone,
+    timeoutMinutes
   });
 
   // このノードは情報表示用（実際のトリガーは別途管理）
   const currentTime = new Date().toISOString();
-  const nextExecution = enabled ? schedulerService.getNextExecution(node.id) : null;
+  const workflowId = StorageService.getCurrentWorkflowId() || node.id;
+  const nextExecution = enabled ? schedulerService.getNextExecution(workflowId) : null;
   
   const scheduleInfo = {
     triggerType: 'Schedule Trigger Node',
@@ -30,6 +34,8 @@ async function executeScheduleNode(node: WorkflowNode, inputs: NodeInputs, conte
     cronExpression,
     scheduleName,
     enabled,
+    timezone: timezone || 'Asia/Tokyo',
+    timeoutMinutes: timeoutMinutes || 30,
     nextExecution: nextExecution?.toISOString() || null,
     note: 'This node triggers the entire workflow at scheduled times'
   };

--- a/src/components/nodes/WebSearchNode.test.ts
+++ b/src/components/nodes/WebSearchNode.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSearchQuery, mapFreshnessForProvider, normalizeSiteFilters } from './WebSearchNode';
+
+describe('WebSearchNode helpers', () => {
+  it('normalizes site filters from mixed input formats', () => {
+    expect(
+      normalizeSiteFilters('https://www.openai.com/blog\ntechcrunch.com, theverge.com/news')
+    ).toEqual(['openai.com', 'techcrunch.com', 'theverge.com']);
+  });
+
+  it('builds a site-constrained search query', () => {
+    expect(
+      buildSearchQuery('AI regulation', ['openai.com', 'techcrunch.com'])
+    ).toBe('AI regulation (site:openai.com OR site:techcrunch.com)');
+  });
+
+  it('maps freshness windows per provider', () => {
+    expect(mapFreshnessForProvider('google', 3)).toEqual({ dateRestrict: 'd3' });
+    expect(mapFreshnessForProvider('brave', 7)).toEqual({ freshness: 'pw' });
+    expect(mapFreshnessForProvider('bing', 30)).toEqual({ freshness: 'Month' });
+  });
+});

--- a/src/components/nodes/WebSearchNode.ts
+++ b/src/components/nodes/WebSearchNode.ts
@@ -7,6 +7,64 @@ import type { WebSearchNodeData } from '../../types/nodeData';
 const searchCache = new Map();
 const CACHE_TTL = 60 * 60 * 1000; // 1時間
 
+const DOMAIN_SEPARATOR = /[\n,]+/;
+
+function sanitizeSiteFilter(value: string): string {
+  return value
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .replace(/^www\./i, '')
+    .replace(/\/.*$/, '');
+}
+
+export function normalizeSiteFilters(siteFilters?: string | string[]): string[] {
+  if (!siteFilters) {
+    return [];
+  }
+
+  const rawValues = Array.isArray(siteFilters)
+    ? siteFilters
+    : siteFilters.split(DOMAIN_SEPARATOR);
+
+  return rawValues
+    .map(sanitizeSiteFilter)
+    .filter(Boolean);
+}
+
+export function buildSearchQuery(query: string, siteFilters?: string | string[]): string {
+  const baseQuery = query.trim();
+  const normalizedSites = normalizeSiteFilters(siteFilters);
+
+  if (normalizedSites.length === 0) {
+    return baseQuery;
+  }
+
+  const siteClause = normalizedSites.map((site) => `site:${site}`).join(' OR ');
+  return `${baseQuery} (${siteClause})`;
+}
+
+export function mapFreshnessForProvider(provider: string, freshnessDays?: number): Record<string, string> {
+  if (!freshnessDays || freshnessDays < 1) {
+    return {};
+  }
+
+  switch (provider) {
+    case 'google':
+      return { dateRestrict: `d${freshnessDays}` };
+    case 'brave':
+      if (freshnessDays <= 1) return { freshness: 'pd' };
+      if (freshnessDays <= 7) return { freshness: 'pw' };
+      if (freshnessDays <= 31) return { freshness: 'pm' };
+      return { freshness: 'py' };
+    case 'bing':
+      if (freshnessDays <= 1) return { freshness: 'Day' };
+      if (freshnessDays <= 7) return { freshness: 'Week' };
+      return { freshness: 'Month' };
+    default:
+      return {};
+  }
+}
+
 // Web検索ノードの実行ロジック
 export async function executeWebSearchNode(node: WorkflowNode, inputs: NodeInputs): Promise<NodeOutput> {
   const data = node.data as WebSearchNodeData;
@@ -16,10 +74,13 @@ export async function executeWebSearchNode(node: WorkflowNode, inputs: NodeInput
     maxResults = 10,
     safeSearch = true,
     language = 'ja',
-    cacheEnabled = true
+    cacheEnabled = true,
+    siteFilters,
+    freshnessDays
   } = data;
   
-  const query = inputs.query || data.query;
+  const rawQuery = inputs.query ?? data.query ?? '';
+  const query = typeof rawQuery === 'string' ? rawQuery : String(rawQuery);
   
   if (!query || !query.trim()) {
     throw new Error('検索クエリが指定されていません');
@@ -31,13 +92,16 @@ export async function executeWebSearchNode(node: WorkflowNode, inputs: NodeInput
   if (!finalApiKey) {
     throw new Error(`${provider}のAPIキーが設定されていません。設定画面でAPIキーを入力してください。`);
   }
+
+  const normalizedSites = normalizeSiteFilters(siteFilters);
+  const effectiveQuery = buildSearchQuery(query, normalizedSites);
   
   // キャッシュチェック
-  const cacheKey = `${provider}:${query}:${maxResults}:${language}`;
+  const cacheKey = `${provider}:${effectiveQuery}:${maxResults}:${language}:${freshnessDays || 'all'}`;
   if (cacheEnabled && searchCache.has(cacheKey)) {
     const cached = searchCache.get(cacheKey);
     if (Date.now() - cached.timestamp < CACHE_TTL) {
-      console.log('Using cached search results for:', query);
+      console.log('Using cached search results for:', effectiveQuery);
       return cached.data;
     }
     searchCache.delete(cacheKey);
@@ -48,13 +112,13 @@ export async function executeWebSearchNode(node: WorkflowNode, inputs: NodeInput
     
     switch (provider) {
       case 'google':
-        results = await searchGoogle(query, finalApiKey, maxResults, language, safeSearch);
+        results = await searchGoogle(effectiveQuery, finalApiKey, maxResults, language, safeSearch, freshnessDays);
         break;
       case 'brave':
-        results = await searchBrave(query, finalApiKey, maxResults, language, safeSearch);
+        results = await searchBrave(effectiveQuery, finalApiKey, maxResults, language, safeSearch, freshnessDays);
         break;
       case 'bing':
-        results = await searchBing(query, finalApiKey, maxResults, language, safeSearch);
+        results = await searchBing(effectiveQuery, finalApiKey, maxResults, language, safeSearch, freshnessDays);
         break;
       default:
         throw new Error(`未対応の検索プロバイダー: ${provider}`);
@@ -68,9 +132,12 @@ export async function executeWebSearchNode(node: WorkflowNode, inputs: NodeInput
       results: normalizedResults.results,
       metadata: {
         query,
+        effectiveQuery,
         provider,
         totalResults: normalizedResults.totalResults,
         searchTime: normalizedResults.searchTime || 0,
+        siteFilters: normalizedSites,
+        freshnessDays: freshnessDays || null,
         cached: false
       },
       error: null
@@ -92,7 +159,10 @@ export async function executeWebSearchNode(node: WorkflowNode, inputs: NodeInput
       results: [],
       metadata: {
         query,
+        effectiveQuery,
         provider,
+        siteFilters: normalizedSites,
+        freshnessDays: freshnessDays || null,
         error: true
       },
       error: error instanceof Error ? error.message : String(error)
@@ -101,7 +171,7 @@ export async function executeWebSearchNode(node: WorkflowNode, inputs: NodeInput
 }
 
 // Google Custom Search API
-async function searchGoogle(query: string, apiKey: string, maxResults: number, language: string, safeSearch: boolean): Promise<any> {
+async function searchGoogle(query: string, apiKey: string, maxResults: number, language: string, safeSearch: boolean, freshnessDays?: number): Promise<any> {
   const searchEngineId = getSearchEngineId('google');
   if (!searchEngineId) {
     throw new Error('Google検索エンジンIDが設定されていません');
@@ -115,6 +185,11 @@ async function searchGoogle(query: string, apiKey: string, maxResults: number, l
     hl: language,
     safe: safeSearch ? 'active' : 'off'
   });
+
+  const freshnessOptions = mapFreshnessForProvider('google', freshnessDays);
+  if (freshnessOptions.dateRestrict) {
+    params.set('dateRestrict', freshnessOptions.dateRestrict);
+  }
   
   const response = await fetch(`https://www.googleapis.com/customsearch/v1?${params}`);
   
@@ -127,13 +202,18 @@ async function searchGoogle(query: string, apiKey: string, maxResults: number, l
 }
 
 // Brave Search API
-async function searchBrave(query: string, apiKey: string, maxResults: number, language: string, safeSearch: boolean): Promise<any> {
+async function searchBrave(query: string, apiKey: string, maxResults: number, language: string, safeSearch: boolean, freshnessDays?: number): Promise<any> {
   const params = new URLSearchParams({
     q: query,
     count: Math.min(maxResults, 20).toString(), // Brave APIは最大20件
     search_lang: language,
     safesearch: safeSearch ? 'strict' : 'off'
   });
+
+  const freshnessOptions = mapFreshnessForProvider('brave', freshnessDays);
+  if (freshnessOptions.freshness) {
+    params.set('freshness', freshnessOptions.freshness);
+  }
   
   const response = await fetch(`https://api.search.brave.com/res/v1/web/search?${params}`, {
     headers: {
@@ -151,13 +231,18 @@ async function searchBrave(query: string, apiKey: string, maxResults: number, la
 }
 
 // Bing Search API
-async function searchBing(query: string, apiKey: string, maxResults: number, language: string, safeSearch: boolean): Promise<any> {
+async function searchBing(query: string, apiKey: string, maxResults: number, language: string, safeSearch: boolean, freshnessDays?: number): Promise<any> {
   const params = new URLSearchParams({
     q: query,
     count: Math.min(maxResults, 50).toString(), // Bing APIは最大50件
     mkt: language === 'ja' ? 'ja-JP' : 'en-US',
     safeSearch: safeSearch ? 'Strict' : 'Off'
   });
+
+  const freshnessOptions = mapFreshnessForProvider('bing', freshnessDays);
+  if (freshnessOptions.freshness) {
+    params.set('freshness', freshnessOptions.freshness);
+  }
   
   const response = await fetch(`https://api.bing.microsoft.com/v7.0/search?${params}`, {
     headers: {
@@ -254,11 +339,13 @@ export const WebSearchNode = createNodeDefinition(
     maxResults: 10,
     safeSearch: true,
     language: 'ja',
-    cacheEnabled: true
+    cacheEnabled: true,
+    siteFilters: '',
+    freshnessDays: 3
   },
   executeWebSearchNode,
   {
-    description: 'Search the web using Google, Brave, or Bing APIs. Returns normalized results.',
+    description: 'Search the web using Google, Brave, or Bing APIs with optional site filters and recency windows. Returns normalized results.',
     category: 'web-integration',
     outputMapping: {
       results: 'results',

--- a/src/data/starterWorkflowTemplates.ts
+++ b/src/data/starterWorkflowTemplates.ts
@@ -184,6 +184,230 @@ export const starterWorkflowTemplates: StarterWorkflowTemplate[] = [
     }
   },
   {
+    id: 'news-monitor-digest',
+    name: 'News Monitor Digest',
+    description: 'Search recent coverage from selected sites and turn it into a scheduled morning digest.',
+    setupLabel: 'Requires search + LLM API keys',
+    highlights: ['Weekday schedule node included', 'Site filters and recent-days search are preconfigured'],
+    icon: '🗞️',
+    workflow: {
+      name: 'News Monitor Digest',
+      description: 'Collect recent articles and summarize them into a daily research digest.',
+      flow: {
+        nodes: [
+          {
+            id: 'schedule_digest',
+            type: 'schedule',
+            position: { x: 40, y: 170 },
+            data: {
+              label: 'Weekday Schedule',
+              cronExpression: '0 8 * * 1-5',
+              scheduleName: 'Weekday News Digest',
+              enabled: false,
+              timeoutMinutes: 20,
+              timezone: 'Asia/Tokyo',
+              width: 240,
+              height: 180
+            }
+          },
+          {
+            id: 'input_topic',
+            type: 'input',
+            position: { x: 320, y: 170 },
+            data: {
+              label: 'Research Topic',
+              value: '生成AI OR LLM OR AI agent',
+              inputType: 'text',
+              width: 240,
+              height: 170
+            }
+          },
+          {
+            id: 'search_news',
+            type: 'web_search',
+            position: { x: 650, y: 145 },
+            data: {
+              label: 'Search Latest Coverage',
+              provider: 'brave',
+              query: '',
+              maxResults: 8,
+              safeSearch: true,
+              language: 'ja',
+              cacheEnabled: true,
+              siteFilters: 'openai.com\ntechcrunch.com\ntheverge.com',
+              freshnessDays: 3,
+              width: 320,
+              height: 280
+            }
+          },
+          {
+            id: 'llm_digest',
+            type: 'llm',
+            position: { x: 1030, y: 145 },
+            data: {
+              label: 'Summarize Digest',
+              prompt: 'Create a concise markdown research digest from the search results. For each important item, include the source, what happened, why it matters, and one follow-up angle to watch next.',
+              systemPrompt: 'You are a practical research analyst. Write compact, source-aware digests in Japanese and avoid repeating the same article.',
+              temperature: 0.3,
+              model: 'gpt-5-nano',
+              width: 320,
+              height: 260
+            }
+          },
+          {
+            id: 'output_digest',
+            type: 'output',
+            position: { x: 1400, y: 180 },
+            data: {
+              label: 'Digest Output',
+              format: 'markdown',
+              title: 'Daily News Digest',
+              fileName: 'daily-news-digest',
+              width: 250,
+              height: 180
+            }
+          }
+        ],
+        edges: [
+          {
+            id: 'conn_news_topic',
+            source: 'input_topic',
+            target: 'search_news',
+            sourceHandle: '0',
+            targetHandle: 'query'
+          },
+          {
+            id: 'conn_news_results',
+            source: 'search_news',
+            target: 'llm_digest',
+            sourceHandle: 'results',
+            targetHandle: '0'
+          },
+          {
+            id: 'conn_news_digest_output',
+            source: 'llm_digest',
+            target: 'output_digest',
+            sourceHandle: '0',
+            targetHandle: '0'
+          }
+        ],
+        viewport: { x: 0, y: 0, zoom: 0.8 }
+      }
+    }
+  },
+  {
+    id: 'site-watch-briefing',
+    name: 'Site Watch Briefing',
+    description: 'Track a specific company or product across target domains and produce a briefing note.',
+    setupLabel: 'Requires search + LLM API keys',
+    highlights: ['Useful for competitor or product watch', 'Ready to narrow searches to specific domains'],
+    icon: '📡',
+    workflow: {
+      name: 'Site Watch Briefing',
+      description: 'Monitor specific domains for product or company updates.',
+      flow: {
+        nodes: [
+          {
+            id: 'schedule_site_watch',
+            type: 'schedule',
+            position: { x: 60, y: 200 },
+            data: {
+              label: 'Daily Schedule',
+              cronExpression: '0 12 * * 1-5',
+              scheduleName: 'Site Watch Briefing',
+              enabled: false,
+              timeoutMinutes: 20,
+              timezone: 'Asia/Tokyo',
+              width: 240,
+              height: 180
+            }
+          },
+          {
+            id: 'input_watch_query',
+            type: 'input',
+            position: { x: 340, y: 200 },
+            data: {
+              label: 'Watch Query',
+              value: 'OpenAI launches OR ChatGPT update OR GPT-5',
+              inputType: 'text',
+              width: 240,
+              height: 170
+            }
+          },
+          {
+            id: 'search_site_watch',
+            type: 'web_search',
+            position: { x: 670, y: 175 },
+            data: {
+              label: 'Search Target Sites',
+              provider: 'brave',
+              query: '',
+              maxResults: 6,
+              safeSearch: true,
+              language: 'en',
+              cacheEnabled: true,
+              siteFilters: 'openai.com\nhelp.openai.com\nplatform.openai.com',
+              freshnessDays: 7,
+              width: 320,
+              height: 280
+            }
+          },
+          {
+            id: 'llm_site_watch',
+            type: 'llm',
+            position: { x: 1050, y: 175 },
+            data: {
+              label: 'Generate Briefing',
+              prompt: 'Turn these search results into a briefing note. Use sections for Changes, Evidence, Potential Impact, and Next Checks. Include source names and links in markdown.',
+              systemPrompt: 'You write concise briefing notes for product and competitive monitoring. Be factual, avoid hype, and make the next action obvious.',
+              temperature: 0.2,
+              model: 'gpt-5-nano',
+              width: 320,
+              height: 260
+            }
+          },
+          {
+            id: 'output_site_watch',
+            type: 'output',
+            position: { x: 1420, y: 210 },
+            data: {
+              label: 'Briefing Output',
+              format: 'markdown',
+              title: 'Site Watch Briefing',
+              fileName: 'site-watch-briefing',
+              width: 250,
+              height: 180
+            }
+          }
+        ],
+        edges: [
+          {
+            id: 'conn_watch_query',
+            source: 'input_watch_query',
+            target: 'search_site_watch',
+            sourceHandle: '0',
+            targetHandle: 'query'
+          },
+          {
+            id: 'conn_watch_results',
+            source: 'search_site_watch',
+            target: 'llm_site_watch',
+            sourceHandle: 'results',
+            targetHandle: '0'
+          },
+          {
+            id: 'conn_watch_output',
+            source: 'llm_site_watch',
+            target: 'output_site_watch',
+            sourceHandle: '0',
+            targetHandle: '0'
+          }
+        ],
+        viewport: { x: 0, y: 0, zoom: 0.78 }
+      }
+    }
+  },
+  {
     id: 'simple-input-output',
     name: 'Simple Input/Output',
     description: 'Start with the smallest possible workflow and verify that data moves through the graph.',

--- a/src/services/workflowManagerService.test.ts
+++ b/src/services/workflowManagerService.test.ts
@@ -208,9 +208,10 @@ describe('workflowManagerService', () => {
       return true;
     });
 
-    const template = starterWorkflowTemplates[2];
+    const template = starterWorkflowTemplates.find((entry) => entry.id === 'simple-input-output');
+    expect(template).toBeDefined();
     const createdWorkflow = workflowManagerService.createWorkflowFromTemplate(
-      template.workflow,
+      template!.workflow,
       'Template Copy'
     );
 
@@ -218,11 +219,11 @@ describe('workflowManagerService', () => {
 
     expect(createdWorkflow.id).toBeDefined();
     expect(createdWorkflow.name).toBe('Template Copy');
-    expect(createdWorkflow.flow).not.toBe(template.workflow.flow);
-    expect(createdWorkflow.flow.nodes).toEqual(template.workflow.flow.nodes);
+    expect(createdWorkflow.flow).not.toBe(template!.workflow.flow);
+    expect(createdWorkflow.flow.nodes).toEqual(template!.workflow.flow.nodes);
 
     const createdInputNode = createdWorkflow.flow.nodes[0] as { data: { label: string } };
-    const templateInputNode = template.workflow.flow.nodes[0] as { data: { label: string } };
+    const templateInputNode = template!.workflow.flow.nodes[0] as { data: { label: string } };
 
     createdInputNode.data.label = 'Changed';
 

--- a/src/types/nodeData.ts
+++ b/src/types/nodeData.ts
@@ -24,6 +24,8 @@ export interface WebSearchNodeData {
   safeSearch?: boolean;
   language?: string;
   cacheEnabled?: boolean;
+  siteFilters?: string;
+  freshnessDays?: number;
 }
 
 // WebAPINode用の型定義
@@ -57,6 +59,7 @@ export interface LLMNodeData {
   provider?: string;
   systemPrompt?: string | null;
   maxTokens?: number | null;
+  prompt?: string;
 }
 
 // TimestampNode用の型定義
@@ -101,6 +104,8 @@ export interface ScheduleNodeData {
   cronExpression?: string;
   scheduleName?: string;
   enabled?: boolean;
+  timezone?: string;
+  timeoutMinutes?: number;
 }
 
 // TextCombinerNode用の型定義


### PR DESCRIPTION
## What changed
- strengthened `Web Search` for recurring research work with target-site filters and provider-specific recency windows
- fixed `LLM` prompt construction so structured inputs are serialized properly and template prompt prefixes are actually used
- wired the `Schedule` node editor so cron presets, enable toggles, timeout edits, and next-run visibility work in the node UI
- added two practical starter workflows: `News Monitor Digest` and `Site Watch Briefing`
- added targeted tests for the new search-query helpers and LLM prompt-building behavior

## Why
The project already had the ingredients for scheduled research collection, but news-monitoring flows were not practical yet: search queries could not be constrained to specific sites or recent windows, LLM nodes did not reliably consume structured search results, and the schedule node UI was not fully wired.

## Impact
Users can now build and run periodic news/site monitoring workflows with less manual setup, more predictable search behavior, and starter templates that map directly to a real recurring research workflow.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`