### PR TITLE
Fix React "Cannot set properties of undefined (setting 'Children')" on GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -35,7 +35,10 @@ function getManualChunkName(id) {
   const normalizedId = id.replace(/\\/g, '/')
 
   for (const group of MANUAL_CHUNK_GROUPS) {
-    if (group.packages.some((pkg) => normalizedId.includes(`/node_modules/${pkg}`))) {
+    if (group.packages.some((pkg) => {
+      const needle = pkg.endsWith('/') ? pkg : `${pkg}/`
+      return normalizedId.includes(`/node_modules/${needle}`)
+    })) {
       return group.name
     }
   }


### PR DESCRIPTION
## 概要

GitHub Pages にデプロイされたビルドで以下のエラーが発生していました:

```
Uncaught TypeError: Cannot set properties of undefined (setting 'Children')
    at ny (vendor-react-S9249lCY.js:17:4266)
    at di (vendor-react-S9249lCY.js:17:7701)
    at od (vendor-misc-BUJ_5iSa.js:22:52)
    at id (vendor-misc-BUJ_5iSa.js:22:891)
```

## 原因

`vite.config.js` の manual chunks 割当関数が `/node_modules/${pkg}` を**部分一致**で判定していたため、`vendor-react` の `react` エントリが `react-remove-scroll` / `react-remove-scroll-bar` / `react-style-singleton` まで巻き込んで `vendor-react` に入れてしまっていました。

これらのパッケージは `use-callback-ref` / `use-sidecar` / `aria-hidden` / `tslib` / `@babel/runtime` などに依存しており、それらは `vendor-misc` に入ります。その結果:

- `vendor-react` → `vendor-misc` (react-remove-scroll が使うユーティリティ)
- `vendor-misc` → `vendor-react` (React 本体)

というチャンク間の**循環 import** が発生。ブラウザで `vendor-misc` が先に評価されると React のネームスペースがまだ初期化されておらず、React 内で `exports.Children = ...` 相当の代入が `undefined.Children =` になって落ちていました。

ビルド出力を確認すると、修正前は実際に両チャンクが相互 import していました:

```js
// vendor-react (修正前)
import {...} from "./vendor-misc-XXX.js"   // ← 循環の片側
// vendor-misc (修正前)
import { R, b, r, a } from "./vendor-react-XXX.js"
```

## 修正内容

パッケージ名の照合時に末尾スラッシュを付けて**厳密な前方一致**にしました。これで `react` は `/node_modules/react/` だけにマッチし、`react-remove-scroll` 系は `vendor-misc` に戻ります。

修正後は `vendor-react` が `vendor-misc` を import しなくなり、循環がほどけて元のエラーが解消されます。

## 動作確認

- `pnpm run build` が成功することを確認
- ビルド出力から `vendor-react` → `vendor-misc` の import が消えていることを確認
- `vite preview` で起動し、jsdom 経由でモジュール初期化中の JS ランタイムエラーが無いことを確認

## Test plan

- [ ] `pnpm run build` が成功する
- [ ] GitHub Pages にデプロイし、ブラウザのコンソールに `Cannot set properties of undefined (setting 'Children')` が出ないことを確認
- [ ] メイン画面が問題なくレンダリングされることを確認

https://claude.ai/code/session_01TYCbiHBgGcDxu54tHscc5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYCbiHBgGcDxu54tHscc5i)_