### PR TITLE
Pin Rollup commonjs helper to vendor-react to break chunk cycle

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -28,11 +28,20 @@ const MANUAL_CHUNK_GROUPS = [
 ]
 
 function getManualChunkName(id) {
-  if (!id.includes('node_modules')) {
-    return undefined
+  const normalizedId = id.replace(/\\/g, '/')
+
+  // Keep Rollup's shared commonjs helper in vendor-react so the React chunk
+  // has no outbound cross-chunk imports. Otherwise Rollup places the helper
+  // in an arbitrary chunk (e.g. vendor-data), which creates a cycle
+  // vendor-react → vendor-data → vendor-misc → vendor-react and causes
+  // "Cannot set properties of undefined (setting 'Children')" at load time.
+  if (normalizedId.includes('commonjsHelpers.js')) {
+    return 'vendor-react'
   }
 
-  const normalizedId = id.replace(/\\/g, '/')
+  if (!normalizedId.includes('node_modules')) {
+    return undefined
+  }
 
   for (const group of MANUAL_CHUNK_GROUPS) {
     if (group.packages.some((pkg) => {


### PR DESCRIPTION
The previous fix removed the direct vendor-react ↔ vendor-misc cycle but a three-hop cycle remained: vendor-react imported Rollup's shared getDefaultExportFromCjs helper (placed by Rollup in vendor-data), vendor-data imported helpers from vendor-misc, and vendor-misc imported React from vendor-react. When vendor-react is evaluated first, the cycle causes vendor-misc's top-level code to run and call li() / requireReact() before vendor-react's own top-level `var X = {}` has executed, so `X` is still undefined and `X.Children = ...` throws.

Force the virtual commonjsHelpers.js module into vendor-react so the React chunk has zero outbound cross-chunk imports. No chunk graph cycle now involves vendor-react.

https://claude.ai/code/session_01TYCbiHBgGcDxu54tHscc5i

## Description
<!-- Describe your changes in detail -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes